### PR TITLE
Refactor internals and align documentation

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -7,7 +7,7 @@ cff-version: 1.2.0
 message: 'To cite package "tidyBdE" in publications use:'
 type: software
 license: GPL-3.0-or-later
-title: 'tidyBdE: Retrieve Data from ''Banco de España'''
+title: 'tidyBdE: Retrieve Time Series Data from ''Banco de España'''
 version: 0.6.1
 doi: 10.32614/CRAN.package.tidyBdE
 identifiers:
@@ -25,7 +25,7 @@ authors:
   orcid: https://orcid.org/0000-0001-8457-4658
 preferred-citation:
   type: manual
-  title: 'tidyBdE: Retrieve Data from Banco de España'
+  title: 'tidyBdE: Retrieve Time Series Data from Banco de España'
   authors:
   - family-names: H. Herrero
     given-names: Diego

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,7 +8,7 @@ message: 'To cite package "tidyBdE" in publications use:'
 type: software
 license: GPL-3.0-or-later
 title: 'tidyBdE: Retrieve Time Series Data from ''Banco de España'''
-version: 0.6.1
+version: 0.6.1.9000
 doi: 10.32614/CRAN.package.tidyBdE
 identifiers:
 - type: doi
@@ -33,7 +33,7 @@ preferred-citation:
     orcid: https://orcid.org/0000-0001-8457-4658
   doi: 10.32614/CRAN.package.tidyBdE
   year: '2026'
-  version: 0.6.1
+  version: 0.6.1.9000
   url: https://ropenspain.github.io/tidyBdE/
   abstract: Tools for retrieving time series data from Banco de España (BdE) as tibble
     objects. Banco de España is the national central bank and, within the framework
@@ -75,6 +75,18 @@ references:
   year: '2026'
   doi: 10.32614/R.manuals
   version: '>= 4.1.0'
+- type: software
+  title: cli
+  abstract: 'cli: Helpers for Developing Command Line Interfaces'
+  notes: Imports
+  url: https://cli.r-lib.org
+  repository: https://CRAN.R-project.org/package=cli
+  authors:
+  - family-names: Csárdi
+    given-names: Gábor
+    email: gabor@posit.co
+  year: '2026'
+  doi: 10.32614/CRAN.package.cli
 - type: software
   title: dplyr
   abstract: 'dplyr: A Grammar of Data Manipulation'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tidyBdE
-Title: Retrieve Data from 'Banco de España'
-Version: 0.6.1
+Title: Retrieve Time Series Data from 'Banco de España'
+Version: 0.6.1.9000
 Authors@R:
     person("Diego", "H. Herrero", , "dev.dieghernan@gmail.com", role = c("aut", "cre", "cph"),
            comment = c(ORCID = "0000-0001-8457-4658"))
@@ -17,6 +17,7 @@ BugReports: https://github.com/rOpenSpain/tidyBdE/issues
 Depends:
     R (>= 4.1.0)
 Imports:
+    cli,
     dplyr (>= 0.7.0),
     ggplot2 (>= 3.5.0),
     readr (>= 1.0.0),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# tidyBdE (development version)
+
+- Internal code was refactored with AI assistance to reduce duplication in indicator wrappers and **ggplot2** scale helpers.
+- Messages and package errors now use **cli**, with AI-assisted wording updates and without the former `tidyBdE>` prefix.
+- Roxygen2 documentation was reviewed with AI assistance and tag order was made consistent across source files.
+- Tests were refactored and expanded with local fixtures, mocks and snapshot updates, reaching 100% line coverage in `devtools:::test_coverage()`.
+
 # tidyBdE 0.6.1
 
 - Improve reading of external `.csv` files by detecting file encoding with
@@ -17,7 +24,7 @@
 # tidyBdE 0.4.0
 
 - `?bde_indicators` is now based on data from the new `?bde_ind_db` database,
-  which clarifies the underlying series identifiers and makes maintenance
+  which clarifies the underlying series codes and makes maintenance
   easier.
 
 # tidyBdE 0.3.8

--- a/R/bde_check_access.R
+++ b/R/bde_check_access.R
@@ -6,20 +6,20 @@
 #'
 #' @return A logical value indicating whether BdE resources are reachable.
 #'
+#' @export
+#' @encoding UTF-8
 #' @keywords internal
 #'
 #' @examples
 #' \donttest{
 #' bde_check_access()
 #' }
-#' @export
-#' @encoding UTF-8
 bde_check_access <- function() {
   # Use an internal option for testing purposes only.
   # nocov start
   test <- getOption("bde_test_offline", NULL)
   if (isTRUE(test)) {
-    message("tidyBdE> Testing offline.")
+    cli::cli_alert_info("Testing offline mode.")
     return(FALSE)
   }
   # nocov end
@@ -54,7 +54,7 @@ skip_if_bde_offline <- function() {
   }
 
   if (requireNamespace("testthat", quietly = TRUE)) {
-    testthat::skip("tidyBdE> BdE API is not reachable.")
+    testthat::skip("BdE API is not reachable.")
   }
   invisible()
   # nocov end

--- a/R/bde_tidy_palettes.R
+++ b/R/bde_tidy_palettes.R
@@ -4,21 +4,22 @@
 #' Manually defined palettes based on BdE publications. Each palette contains
 #' at most six colors.
 #'
-#' @family bde_plot
+#' @param n The number of colors (`>= 1`) to return.
+#' @param palette A valid palette name.
+#' @param alpha Alpha transparency level in the range `[0, 1]`, where `0` is
+#'   transparent and `1` is opaque. If `alpha = NULL`, the function does not
+#'   append opacity codes (`"FF"`) to individual color hex codes. See
+#'   [ggplot2::alpha()].
+#' @param rev Logical indicating whether to reverse the color order.
 #'
 #' @return A character vector of hex color codes.
 #'
+#' @family bde_plot
+#'
 #' @export
 #' @encoding UTF-8
-#' @param n The number of colors (`>= 1`) to return.
-#' @param palette A valid palette name.
-#' @param alpha An alpha transparency level in the range `[0, 1]` (`0` means
-#'   transparent and `1` means opaque). If missing (i.e., `alpha = NULL`), the
-#'   function does not append opacity codes (`"FF"`) to the individual color
-#'   hex codes. See [ggplot2::alpha()].
-#' @param rev Logical indicating whether to reverse the color order.
-#' @examples
 #'
+#' @examples
 #' # Show the BdE vivid palette.
 #' scales::show_col(bde_tidy_palettes(palette = "bde_vivid_pal"),
 #'   labels = FALSE
@@ -70,16 +71,11 @@ bde_tidy_palettes <- function(
 
   n_col <- length(cols)
   if (n > n_col) {
-    message(
-      "tidyBdE> ",
-      palette,
-      " contains ",
-      n_col,
-      " colors. You requested ",
-      n,
-      ". Returning ",
-      n_col,
-      " colors."
+    cli::cli_alert_warning(
+      paste0(
+        "Palette {.val {palette}} contains {n_col} colors. ",
+        "You requested {n}. Returning {n_col} colors."
+      )
     )
 
     n <- n_col

--- a/R/catalogs.R
+++ b/R/catalogs.R
@@ -3,32 +3,12 @@
 #' @description
 #' Load BdE time series catalog metadata.
 #'
-#' @export
-#' @encoding UTF-8
-#'
-#' @family catalog
-#'
-#' @return A [tibble][tibble::tbl_df] with the requested catalog metadata.
-#'
-#' @source
-#'
-#' ```{r, echo=FALSE, results='asis'}
-#'
-#' cat(paste0("[time series bulk data download]",
-#'       "(https://www.bde.es/webbe/en/estadisticas/recursos/",
-#'       "descargas-completas.html)."))
-#'
-#' ```
-#'
 #' @param catalog A single catalog identifier to load, or `"ALL"` to load every
 #'   catalog. See **Details**.
-#'
 #' @param parse_dates Logical. If `TRUE`, date columns are parsed with
 #'   [bde_parse_dates()].
-#'
 #' @param update_cache Logical. If `TRUE`, the requested file is refreshed in
 #'   `cache_dir`.
-#'
 #' @inheritParams bde_catalog_update
 #'
 #' @details
@@ -46,7 +26,7 @@
 #' )
 #'
 #' names(t) <- paste0("**",
-#'   c("CODE","PUBLICATION", "UPDATE FREQUENCY", "FREQUENCY"),
+#'   c("CODE", "PUBLICATION", "UPDATE FREQUENCY", "FREQUENCY"),
 #'   "**")
 #'
 #' knitr::kable(t)
@@ -55,6 +35,23 @@
 #'
 #' If the requested catalog is not cached, this function calls
 #' [bde_catalog_update()].
+#'
+#' @return A [tibble][tibble::tbl_df] with the requested catalog metadata.
+#'
+#' @source
+#'
+#' ```{r, echo=FALSE, results='asis'}
+#'
+#' cat(paste0("[Time series bulk data download]",
+#'       "(https://www.bde.es/webbe/en/estadisticas/recursos/",
+#'       "descargas-completas.html)."))
+#'
+#' ```
+#'
+#' @family catalog
+#'
+#' @export
+#' @encoding UTF-8
 #'
 #' @examplesIf bde_check_access()
 #' \donttest{
@@ -84,7 +81,7 @@ bde_catalog_load <- function(
     catalog_to_load <- setdiff(valid_catalogs, "ALL")
   }
 
-  # Resolve the cache directory.
+  # Honor the configured cache location before reading or downloading files.
   cache_dir <- bde_hlp_cachedir(cache_dir = cache_dir, verbose = verbose)
 
   final_catalog <- lapply(catalog_to_load, function(x) {
@@ -93,11 +90,11 @@ bde_catalog_load <- function(
     has_cache <- file.exists(catalog_file)
 
     if (all(has_cache, isFALSE(update_cache))) {
-      if (verbose) message("tidyBdE> Cached version of ", x, " detected.")
+      if (verbose) cli::cli_alert_success("Using cached catalog {.val {x}}.")
     } else {
       # Download the catalog when it is missing or must be refreshed.
       if (verbose) {
-        message("tidyBdE> Need to download catalog ", x, ".")
+        cli::cli_alert_info("Downloading catalog {.val {x}}.")
       }
 
       result <- bde_catalog_update(
@@ -108,16 +105,18 @@ bde_catalog_load <- function(
 
       # Handle download errors.
       if (any(is.data.frame(result), isFALSE(result))) {
-        message("tidyBdE> Download is not available for ", x, ".")
+        cli::cli_alert_warning(
+          "Catalog {.val {x}} is not available for download."
+        )
         return(NULL)
       }
     }
 
-    # Handle empty files.
+    # Reject empty files before encoding detection.
     # nocov start
     r <- readLines(catalog_file, warn = FALSE, n = 1000)
     if (length(r) == 0) {
-      message("tidyBdE> File ", catalog_file, " is not valid.")
+      cli::cli_alert_warning("File {.file {catalog_file}} is not valid.")
       return(invisible())
     }
     # nocov end
@@ -135,8 +134,7 @@ bde_catalog_load <- function(
       )
     )
 
-    # Use stable column names.
-    # Use hard-coded column names to avoid UTF-8 check failures.
+    # Avoid UTF-8 check failures from upstream Spanish column names.
     names_catalog <- c(
       "Nombre_de_la_serie",
       "Numero_secuencial",
@@ -157,7 +155,7 @@ bde_catalog_load <- function(
       "Notas"
     )
 
-    # Set column names and remove the original header.
+    # Remove the upstream header after assigning stable column names.
     names(catalog_load) <- names_catalog
     catalog_load <- catalog_load[-1, ]
 
@@ -168,8 +166,13 @@ bde_catalog_load <- function(
   res_all <- unlist(lapply(final_catalog, is.null))
 
   if (any(res_all)) {
-    msg <- paste0(catalog_to_load[res_all], collapse = ", ")
-    message("tidyBdE> Could not load catalogs: ", msg, ".")
+    cli::cli_alert_warning(
+      paste0(
+        "Could not load catalogs: ",
+        paste0(catalog_to_load[res_all], collapse = ", "),
+        "."
+      )
+    )
   }
 
   # Combine catalogs and infer column types.
@@ -179,13 +182,13 @@ bde_catalog_load <- function(
     preserve = names(final_catalog)[c(5, 15)]
   )
 
-  # Return the result as a tibble.
+  # Keep the public return type stable.
   final_catalog <- tibble::as_tibble(final_catalog)
 
-  # Parse date columns.
+  # Parse date columns after type inference.
   if (parse_dates) {
     if (verbose) {
-      message("tidyBdE> Parsing dates.")
+      cli::cli_alert_info("Parsing date columns.")
     }
     date_fields <- names(final_catalog)[grep(
       "Fecha",
@@ -206,27 +209,10 @@ bde_catalog_load <- function(
 #' @description
 #' Update BdE time series catalog files.
 #'
-#' @export
-#' @encoding UTF-8
-#'
-#' @family catalog
-#'
-#' @return An invisible list of download results.
-#'
-#' @source
-#'
-#' ```{r, echo=FALSE, results='asis'}
-#'
-#' cat(paste0("[time series bulk data download]",
-#'       "(https://www.bde.es/webbe/en/estadisticas/recursos/",
-#'       "descargas-completas.html)."))
-#'
-#' ```
-#'
 #' @param catalog A single catalog identifier to update, or `"ALL"` to update
 #'   every catalog. See **Details**.
-#' @param cache_dir A path to a cache directory. The directory can also be set
-#'   with options using `options(bde_cache_dir = "path/to/dir")`.
+#' @param cache_dir Path to a cache directory. The directory can also be set
+#'   with `options(bde_cache_dir = "path/to/dir")`.
 #' @param verbose Logical. If `TRUE`, display information useful for debugging.
 #'
 #' @details
@@ -244,13 +230,30 @@ bde_catalog_load <- function(
 #' )
 #'
 #' names(t) <- paste0("**",
-#'   c("CODE","PUBLICATION", "UPDATE FREQUENCY", "FREQUENCY"),
+#'   c("CODE", "PUBLICATION", "UPDATE FREQUENCY", "FREQUENCY"),
 #'   "**")
 #'
 #' knitr::kable(t)
 #'
 #' ```
 #' Use `"ALL"` as a shorthand for updating all catalogs at once.
+#'
+#' @return An invisible list of download results.
+#'
+#' @source
+#'
+#' ```{r, echo=FALSE, results='asis'}
+#'
+#' cat(paste0("[Time series bulk data download]",
+#'       "(https://www.bde.es/webbe/en/estadisticas/recursos/",
+#'       "descargas-completas.html)."))
+#'
+#' ```
+#'
+#' @family catalog
+#'
+#' @export
+#' @encoding UTF-8
 #'
 #' @examplesIf bde_check_access()
 #' \donttest{
@@ -277,19 +280,18 @@ bde_catalog_update <- function(
   }
   # nocov end
 
-  # Resolve the cache directory.
+  # Honor the configured cache location before downloading files.
   cache_dir <- bde_hlp_cachedir(cache_dir = cache_dir, verbose = verbose)
 
-  # Download the requested catalogs.
+  # Expand `"ALL"` to the individual catalog files.
   catalog_download <- catalog
   if ("ALL" %in% catalog) {
     catalog_download <- valid_catalogs[valid_catalogs != "ALL"]
   }
 
   if (verbose) {
-    message(
-      "tidyBdE> Updating catalogs: ",
-      paste0(catalog_download, collapse = ", ")
+    cli::cli_alert_info(
+      "Updating catalogs: {paste0(catalog_download, collapse = ', ')}."
     )
   }
 
@@ -304,7 +306,7 @@ bde_catalog_update <- function(
     full_url <- paste0(base_url, catalog_file)
     local_file <- file.path(cache_dir, catalog_file)
 
-    # Download the catalog.
+    # Store each catalog in the resolved cache directory.
     result <- bde_hlp_download(
       url = full_url,
       local_file = local_file,
@@ -321,26 +323,25 @@ bde_catalog_update <- function(
 #' @description
 #' Search BdE time series catalog metadata for keywords.
 #'
-#' @export
-#' @encoding UTF-8
-#'
-#' @family catalog
-#'
-#' @return A [tibble][tibble::tbl_df] object with the results of the query.
-#'
 #' @param pattern [`regex`][base::regex] pattern to search. See **Details**
 #'   and **Examples**.
-#'
 #' @inheritDotParams bde_catalog_load
 #'
 #' @details
-#' **Note:** BdE metadata is currently provided in Spanish only. Therefore,
-#' search terms must be provided in Spanish to retrieve results.
+#' **Note:** BdE metadata is currently available in Spanish only. Therefore,
+#' search terms must be in Spanish to retrieve results.
 #'
 #' This function uses [base::grep()] to find matches in the catalogs. You can
 #' pass [regular expressions][base::regex] to broaden the search.
 #'
+#' @return A [tibble][tibble::tbl_df] object with the results of the query.
+#'
 #' @seealso [bde_catalog_load()], [base::regex]
+#'
+#' @family catalog
+#'
+#' @export
+#' @encoding UTF-8
 #'
 #' @examplesIf bde_check_access()
 #' \donttest{
@@ -356,7 +357,7 @@ bde_catalog_update <- function(
 #' bde_catalog_search("Francia(.*)PIB|Italia(.*)PIB|Alemania(.*)PIB")
 #' }
 bde_catalog_search <- function(pattern, ...) {
-  # Extract catalog data.
+  # Reuse the catalog loader so search honors the same cache and parsing rules.
   catalog_search <- bde_catalog_load(...)
 
   # nocov start
@@ -366,19 +367,20 @@ bde_catalog_search <- function(pattern, ...) {
   }
 
   if (!tibble::is_tibble(catalog_search)) {
-    message(
-      "tidyBdE> Catalogs are corrupted. Try redownloading with ",
-      "bde_catalog_update()."
+    cli::cli_alert_warning(
+      paste0(
+        "Catalog data is not a tibble. Try redownloading it with ",
+        "bde_catalog_update()."
+      )
     )
     return(invisible())
   }
   # nocov end
 
-  # Define indices for search columns.
+  # Search the metadata fields most useful for discovery.
   col_ind <- c(2, 3, 4, 5, 15)
 
   search_match_rows <- NULL
-  # Search across the specified columns.
   for (i in col_ind) {
     search_match_rows <- unique(
       c(
@@ -390,7 +392,7 @@ bde_catalog_search <- function(pattern, ...) {
 
   search_results <- catalog_search[search_match_rows, ]
   if (nrow(search_results) == 0) {
-    stop("tidyBdE> No matches found for ", pattern, ".")
+    cli::cli_abort("No matches found for {.val {pattern}}.")
   }
   search_results
 }

--- a/R/data.R
+++ b/R/data.R
@@ -5,31 +5,29 @@
 #' in the convenience functions of \CRANpkg{tidyBdE} (see [bde_indicators]).
 #' Full metadata can be accessed with [bde_catalog_load()].
 #'
-#' @docType data
+#' @details
 #'
-#' @family indicators
-#'
-#' @encoding UTF-8
-#'
-#' @name bde_ind_db
+#' ```{r child = "man/chunks/bde_ind_db_meta.Rmd"}
+#' ```
 #'
 #' @format
 #' A [tibble][tibble::tbl_df] of `r nrow(bde_ind_db)` rows and
 #' `r ncol(bde_ind_db)` columns with the following fields:
 #'
 #' \describe{
-#'   \item{tidyBdE_fun}{Function name, see [bde_indicators].}
-#'   \item{Numero_secuencial}{Series code, see [bde_series_load()].}
+#'   \item{tidyBdE_fun}{Function name. See [bde_indicators].}
+#'   \item{Numero_secuencial}{Series code. See [bde_series_load()].}
 #'   \item{Descripcion_de_la_serie}{Description of the series in Spanish.}
 #'   \item{Fecha_de_la_primera_observacion}{Starting date of the indicator.}
 #'   \item{Fecha_de_la_ultima_observacion}{Most recent date available.}
 #'   \item{Fuente}{Data source.}
 #' }
 #'
-#' @details
+#' @family indicators
 #'
-#' ```{r child = "man/chunks/bde_ind_db_meta.Rmd"}
-#' ```
+#' @name bde_ind_db
+#' @docType data
+#' @encoding UTF-8
 #'
 #' @examples
 #' data("bde_ind_db")

--- a/R/indicators.R
+++ b/R/indicators.R
@@ -4,40 +4,32 @@
 #' Convenience functions for downloading selected Spanish macroeconomic
 #' indicators. Metadata is available in [bde_ind_db].
 #'
-#' @rdname bde_indicators
-#' @name bde_indicators
-#'
-#' @export
-#' @encoding UTF-8
-#'
-#' @family indicators
-#'
 #' @inheritParams bde_series_load
-#'
 #' @inheritDotParams bde_series_load -series_code
-#'
-#' @return A [tibble][tibble::tbl_df] with the required series.
-#'
-#' @seealso [bde_series_load()], [bde_catalog_search()]
 #'
 #' @details
 #' These functions are convenient wrappers around [bde_series_load()] for
 #' specific series. Use `verbose = TRUE, extract_metadata = TRUE` to inspect the
 #' metadata and source.
 #'
+#' @return A [tibble][tibble::tbl_df] with the required series.
+#'
+#' @seealso [bde_series_load()], [bde_catalog_search()]
+#'
+#' @family indicators
+#'
+#' @rdname bde_indicators
+#' @name bde_indicators
+#'
+#' @export
+#' @encoding UTF-8
+#'
 #' @examplesIf bde_check_access()
 #' \donttest{
 #' bde_ind_gdp_var()
 #' }
 bde_ind_gdp_var <- function(series_label = "GDP_YoY", ...) {
-  db <- tidyBdE::bde_ind_db
-  seq_num <- db[db$tidyBdE_fun == "bde_ind_gdp_var", "Numero_secuencial"]
-  seq_num <- as.character(seq_num)
-
-  econom_ind <- bde_series_load(seq_num, series_label = series_label, ...)
-  econom_ind <- econom_ind[!is.na(econom_ind[[2]]), ]
-
-  econom_ind
+  bde_hlp_indicator("bde_ind_gdp_var", series_label, ...)
 }
 
 #' @rdname bde_indicators
@@ -45,17 +37,7 @@ bde_ind_gdp_var <- function(series_label = "GDP_YoY", ...) {
 #' @export
 #' @encoding UTF-8
 bde_ind_unemployment_rate <- function(series_label = "Unemployment_Rate", ...) {
-  db <- tidyBdE::bde_ind_db
-  seq_num <- db[
-    db$tidyBdE_fun == "bde_ind_unemployment_rate",
-    "Numero_secuencial"
-  ]
-  seq_num <- as.character(seq_num)
-
-  econom_ind <- bde_series_load(seq_num, series_label = series_label, ...)
-  econom_ind <- econom_ind[!is.na(econom_ind[[2]]), ]
-
-  econom_ind
+  bde_hlp_indicator("bde_ind_unemployment_rate", series_label, ...)
 }
 
 #' @rdname bde_indicators
@@ -66,17 +48,7 @@ bde_ind_euribor_12m_monthly <- function(
   series_label = "Euribor_12M_Monthly",
   ...
 ) {
-  db <- tidyBdE::bde_ind_db
-  seq_num <- db[
-    db$tidyBdE_fun == "bde_ind_euribor_12m_monthly",
-    "Numero_secuencial"
-  ]
-  seq_num <- as.character(seq_num)
-
-  econom_ind <- bde_series_load(seq_num, series_label = series_label, ...)
-  econom_ind <- econom_ind[!is.na(econom_ind[[2]]), ]
-
-  econom_ind
+  bde_hlp_indicator("bde_ind_euribor_12m_monthly", series_label, ...)
 }
 
 #' @rdname bde_indicators
@@ -84,17 +56,7 @@ bde_ind_euribor_12m_monthly <- function(
 #' @export
 #' @encoding UTF-8
 bde_ind_euribor_12m_daily <- function(series_label = "Euribor_12M_Daily", ...) {
-  db <- tidyBdE::bde_ind_db
-  seq_num <- db[
-    db$tidyBdE_fun == "bde_ind_euribor_12m_daily",
-    "Numero_secuencial"
-  ]
-  seq_num <- as.character(seq_num)
-
-  econom_ind <- bde_series_load(seq_num, series_label = series_label, ...)
-  econom_ind <- econom_ind[!is.na(econom_ind[[2]]), ]
-
-  econom_ind
+  bde_hlp_indicator("bde_ind_euribor_12m_daily", series_label, ...)
 }
 
 #' @rdname bde_indicators
@@ -102,14 +64,7 @@ bde_ind_euribor_12m_daily <- function(series_label = "Euribor_12M_Daily", ...) {
 #' @export
 #' @encoding UTF-8
 bde_ind_cpi_var <- function(series_label = "Consumer_price_index_YoY", ...) {
-  db <- tidyBdE::bde_ind_db
-  seq_num <- db[db$tidyBdE_fun == "bde_ind_cpi_var", "Numero_secuencial"]
-  seq_num <- as.character(seq_num)
-
-  econom_ind <- bde_series_load(seq_num, series_label = series_label, ...)
-  econom_ind <- econom_ind[!is.na(econom_ind[[2]]), ]
-
-  econom_ind
+  bde_hlp_indicator("bde_ind_cpi_var", series_label, ...)
 }
 
 #' @rdname bde_indicators
@@ -117,14 +72,7 @@ bde_ind_cpi_var <- function(series_label = "Consumer_price_index_YoY", ...) {
 #' @export
 #' @encoding UTF-8
 bde_ind_ibex_monthly <- function(series_label = "IBEX_index_month", ...) {
-  db <- tidyBdE::bde_ind_db
-  seq_num <- db[db$tidyBdE_fun == "bde_ind_ibex_monthly", "Numero_secuencial"]
-  seq_num <- as.character(seq_num)
-
-  econom_ind <- bde_series_load(seq_num, series_label = series_label, ...)
-  econom_ind <- econom_ind[!is.na(econom_ind[[2]]), ]
-
-  econom_ind
+  bde_hlp_indicator("bde_ind_ibex_monthly", series_label, ...)
 }
 
 #' @rdname bde_indicators
@@ -132,14 +80,7 @@ bde_ind_ibex_monthly <- function(series_label = "IBEX_index_month", ...) {
 #' @export
 #' @encoding UTF-8
 bde_ind_ibex_daily <- function(series_label = "IBEX_index_day", ...) {
-  db <- tidyBdE::bde_ind_db
-  seq_num <- db[db$tidyBdE_fun == "bde_ind_ibex_daily", "Numero_secuencial"]
-  seq_num <- as.character(seq_num)
-
-  econom_ind <- bde_series_load(seq_num, series_label = series_label, ...)
-  econom_ind <- econom_ind[!is.na(econom_ind[[2]]), ]
-
-  econom_ind
+  bde_hlp_indicator("bde_ind_ibex_daily", series_label, ...)
 }
 
 #' @rdname bde_indicators
@@ -147,14 +88,7 @@ bde_ind_ibex_daily <- function(series_label = "IBEX_index_day", ...) {
 #' @export
 #' @encoding UTF-8
 bde_ind_gdp_quarterly <- function(series_label = "GDP_quarterly_value", ...) {
-  db <- tidyBdE::bde_ind_db
-  seq_num <- db[db$tidyBdE_fun == "bde_ind_gdp_quarterly", "Numero_secuencial"]
-  seq_num <- as.character(seq_num)
-
-  econom_ind <- bde_series_load(seq_num, series_label = series_label, ...)
-  econom_ind <- econom_ind[!is.na(econom_ind[[2]]), ]
-
-  econom_ind
+  bde_hlp_indicator("bde_ind_gdp_quarterly", series_label, ...)
 }
 
 #' @rdname bde_indicators
@@ -162,18 +96,26 @@ bde_ind_gdp_quarterly <- function(series_label = "GDP_quarterly_value", ...) {
 #' @export
 #' @encoding UTF-8
 bde_ind_population <- function(series_label = "Population_Spain", ...) {
+  bde_hlp_indicator("bde_ind_population", series_label, ...)
+}
+
+#' @rdname bde_indicators
+#' @usage NULL
+#' @export
+#' @encoding UTF-8
+bde_ind_ibex <- bde_ind_ibex_monthly
+
+#' Load one indicator wrapper
+#'
+#' @param function_name Name used in `bde_ind_db$tidyBdE_fun`.
+#' @param series_label Series label to pass to [bde_series_load()].
+#' @param ... Additional arguments passed to [bde_series_load()].
+#' @noRd
+bde_hlp_indicator <- function(function_name, series_label, ...) {
   db <- tidyBdE::bde_ind_db
-  seq_num <- db[db$tidyBdE_fun == "bde_ind_population", "Numero_secuencial"]
+  seq_num <- db[db$tidyBdE_fun == function_name, "Numero_secuencial"]
   seq_num <- as.character(seq_num)
 
   econom_ind <- bde_series_load(seq_num, series_label = series_label, ...)
-  econom_ind <- econom_ind[!is.na(econom_ind[[2]]), ]
-
-  econom_ind
+  econom_ind[!is.na(econom_ind[[2]]), ]
 }
-
-#' @export
-#' @encoding UTF-8
-#' @rdname bde_indicators
-#' @usage NULL
-bde_ind_ibex <- bde_ind_ibex_monthly

--- a/R/scales.R
+++ b/R/scales.R
@@ -4,26 +4,23 @@
 #' Color scales for the \CRANpkg{ggplot2} package. Discrete scales are
 #' named `scale_*_bde_d`, while continuous palettes are named `scale_*_bde_c`.
 #'
+#' @param palette BdE palette to apply. See [bde_tidy_palettes()] for details.
+#' @inheritParams bde_tidy_palettes
+#' @inheritParams ggplot2::continuous_scale
+#' @param ... Additional arguments passed to [ggplot2::discrete_scale()] or
+#'   [ggplot2::continuous_scale()].
+#'
+#' @return A \CRANpkg{ggplot2} scale object.
+#'
 #' @seealso [ggplot2::discrete_scale()], [ggplot2::continuous_scale()]
 #'
 #' @family bde_plot
 #'
-#' @export
-#' @encoding UTF-8
-#'
-#' @return A \CRANpkg{ggplot2} scale object.
-#'
 #' @rdname scales_bde
-#'
 #' @name scales_bde
 #'
-#' @param palette BdE palette to apply. See [bde_tidy_palettes()] for details.
-#'
-#' @inheritParams bde_tidy_palettes
-#' @inheritParams ggplot2::continuous_scale
-#'
-#' @param ... Additional arguments passed to [ggplot2::discrete_scale()] or
-#'   [ggplot2::continuous_scale()].
+#' @export
+#' @encoding UTF-8
 #'
 #' @examples
 #' library(ggplot2)
@@ -54,19 +51,20 @@ scale_color_bde_d <- function(
   ...
 ) {
   palette <- match.arg(palette)
-
-  # Build the discrete palette.
-  cols_v <- bde_tidy_palettes(palette = palette, alpha = alpha, rev = rev)
-  pal <- scales::manual_pal(cols_v)
-
-  ggplot2::discrete_scale(aesthetics = "color", palette = pal, ...)
+  bde_scale_bde_d(
+    aesthetics = "color",
+    palette = palette,
+    alpha = alpha,
+    rev = rev,
+    ...
+  )
 }
 
 #' @rdname scales_bde
 #' @name scales_bde
+#' @usage NULL
 #' @export
 #' @encoding UTF-8
-#' @usage NULL
 scale_colour_bde_d <- scale_color_bde_d
 
 #' @rdname scales_bde
@@ -80,12 +78,13 @@ scale_fill_bde_d <- function(
   ...
 ) {
   palette <- match.arg(palette)
-
-  # Build the discrete palette.
-  cols_v <- bde_tidy_palettes(palette = palette, alpha = alpha, rev = rev)
-  pal <- scales::manual_pal(cols_v)
-
-  ggplot2::discrete_scale(aesthetics = "fill", palette = pal, ...)
+  bde_scale_bde_d(
+    aesthetics = "fill",
+    palette = palette,
+    alpha = alpha,
+    rev = rev,
+    ...
+  )
 }
 
 #' @rdname scales_bde
@@ -100,31 +99,11 @@ scale_color_bde_c <- function(
   ...
 ) {
   palette <- match.arg(palette)
-
-  # Define the color ramp for the continuous scale.
-  cols <- switch(palette,
-    "bde_vivid_pal" = bde_tidy_palettes(
-      6,
-      "bde_vivid_pal",
-      alpha = alpha,
-      rev = rev
-    ),
-    "bde_qual_pal" = bde_tidy_palettes(
-      6,
-      "bde_qual_pal",
-      alpha = alpha,
-      rev = rev
-    ),
-    "bde_rose_pal" = bde_tidy_palettes(
-      6,
-      "bde_rose_pal",
-      alpha = alpha,
-      rev = rev
-    )[c(1, 2, 3, 6, 5, 4)]
-  )
-  ggplot2::continuous_scale(
+  bde_scale_bde_c(
     aesthetics = "color",
-    palette = scales::gradient_n_pal(cols),
+    palette = palette,
+    alpha = alpha,
+    rev = rev,
     guide = guide,
     ...
   )
@@ -132,9 +111,9 @@ scale_color_bde_c <- function(
 
 #' @rdname scales_bde
 #' @name scales_bde
+#' @usage NULL
 #' @export
 #' @encoding UTF-8
-#' @usage NULL
 scale_colour_bde_c <- scale_color_bde_c
 
 #' @rdname scales_bde
@@ -149,33 +128,59 @@ scale_fill_bde_c <- function(
   ...
 ) {
   palette <- match.arg(palette)
-
-  # Define the color ramp for the continuous scale.
-  cols <- switch(palette,
-    "bde_vivid_pal" = bde_tidy_palettes(
-      6,
-      "bde_vivid_pal",
-      alpha = alpha,
-      rev = rev
-    ),
-    "bde_qual_pal" = bde_tidy_palettes(
-      6,
-      "bde_qual_pal",
-      alpha = alpha,
-      rev = rev
-    ),
-    "bde_rose_pal" = bde_tidy_palettes(
-      6,
-      "bde_rose_pal",
-      alpha = alpha,
-      rev = rev
-    )[c(1, 2, 3, 6, 5, 4)]
-  )
-
-  ggplot2::continuous_scale(
+  bde_scale_bde_c(
     aesthetics = "fill",
+    palette = palette,
+    alpha = alpha,
+    rev = rev,
+    guide = guide,
+    ...
+  )
+}
+
+#' Build a discrete BdE scale
+#'
+#' @param aesthetics Scale aesthetics.
+#' @param palette BdE palette to apply.
+#' @inheritParams bde_tidy_palettes
+#' @param ... Additional arguments passed to [ggplot2::discrete_scale()].
+#' @noRd
+bde_scale_bde_d <- function(aesthetics, palette, alpha, rev, ...) {
+  cols <- bde_tidy_palettes(palette = palette, alpha = alpha, rev = rev)
+  ggplot2::discrete_scale(
+    aesthetics = aesthetics,
+    palette = scales::manual_pal(cols),
+    ...
+  )
+}
+
+#' Build a continuous BdE scale
+#'
+#' @param aesthetics Scale aesthetics.
+#' @param palette BdE palette to apply.
+#' @inheritParams bde_tidy_palettes
+#' @inheritParams ggplot2::continuous_scale
+#' @param ... Additional arguments passed to [ggplot2::continuous_scale()].
+#' @noRd
+bde_scale_bde_c <- function(aesthetics, palette, alpha, rev, guide, ...) {
+  cols <- bde_scale_bde_c_cols(palette, alpha = alpha, rev = rev)
+  ggplot2::continuous_scale(
+    aesthetics = aesthetics,
     palette = scales::gradient_n_pal(cols),
     guide = guide,
     ...
   )
+}
+
+#' Return colors for continuous BdE scales
+#'
+#' @param palette BdE palette to apply.
+#' @inheritParams bde_tidy_palettes
+#' @noRd
+bde_scale_bde_c_cols <- function(palette, alpha, rev) {
+  cols <- bde_tidy_palettes(6, palette, alpha = alpha, rev = rev)
+  if (palette == "bde_rose_pal") {
+    cols <- cols[c(1, 2, 3, 6, 5, 4)]
+  }
+  cols
 }

--- a/R/series.R
+++ b/R/series.R
@@ -1,26 +1,28 @@
 #' Load a single BdE time series
 #'
+#' @description
 #' Load a single BdE time series.
 #'
-#' @export
-#' @encoding UTF-8
+#' The series alias is a positional code showing the location (column and/or
+#' row) of the series in the table. Although it is unique, it is not stable
+#' enough to identify a time series because it may change when the series moves.
 #'
-#' @family series
+#' To ensure series can still be identified after these changes, they are
+#' assigned a sequential number, referred to as `series_code` in this function.
 #'
-#' @param series_code A numeric value, or one coercible with
-#'   [base::as.double()], or a vector of time series codes, as defined in the
-#'   field
-#'   `Número secuencial` of the corresponding series. See [bde_catalog_load()].
+#' A single time series may appear in different tables, so it can have several
+#' aliases. If you need to search by alias, use [bde_series_full_load()].
 #'
+#' @param series_code Numeric value, value coercible with [base::as.double()],
+#'   or vector of time series codes from the `Número secuencial` field of the
+#'   corresponding series. See [bde_catalog_load()].
 #' @param series_label Optional character string or vector of labels to assign
 #'   to the extracted series.
-#'
-#' @param out_format The format to return, either `"wide"` or `"long"`.
-#'   See **Value** for details and the **Examples** section.
+#' @param out_format The format to return, either `"wide"` or `"long"`. See
+#'   **Value** for details and the **Examples** section.
 #' @inheritParams bde_series_full_load
 #'
-#' @return
-#' A [tibble][tibble::tbl_df] with a `Date` column:
+#' @return A [tibble][tibble::tbl_df] with a `Date` column:
 #'
 #' - With `out_format = "wide"`, each series is presented in a separate column
 #'   with the name defined by `series_label`.
@@ -33,25 +35,17 @@
 #' [ggplot2::ggplot()]. See also [tidyr::pivot_longer()] and
 #' [tidyr::pivot_wider()].
 #'
-#' @description
-#'
-#' The series alias is a positional code showing the location (column and/or
-#' row) of the series in the table. Although it is unique, it is not stable
-#' enough to use as the series ID because it may change when the series moves.
-#'
-#' To ensure series can still be identified after these changes, they are
-#' assigned a sequential number, referred to as `series_code` in this function.
-#'
-#' Note that a single series may appear in different tables, so it can have
-#' several aliases. If you need to search by alias, use
-#' [bde_series_full_load()].
-#'
 #' @note
-#' This function attempts to coerce the columns to numbers. For some series, a
-#' warning may be displayed if the parsing fails.
+#' This function attempts to coerce the columns to numbers. For some time
+#' series, a warning may be displayed if the parsing fails.
 #'
 #' @seealso [bde_catalog_load()],
 #' [bde_catalog_search()], [bde_indicators()]
+#'
+#' @family series
+#'
+#' @export
+#' @encoding UTF-8
 #'
 #' @examplesIf bde_check_access()
 #' \donttest{
@@ -102,24 +96,26 @@ bde_series_load <- function(
   extract_metadata = FALSE
 ) {
   if (missing(series_code)) {
-    stop("tidyBdE> `series_code` cannot be missing.")
+    cli::cli_abort("{.arg series_code} cannot be missing.")
   }
 
   series_code <- as.double(series_code)
-  # Remove missing values.
+  # Drop invalid codes created by coercion.
   series_code <- series_code[!is.na(series_code)]
 
   if (is.null(series_label)) {
     series_label <- as.character(series_code)
   }
   if (anyNA(series_label)) {
-    stop("tidyBdE> `series_label` must not contain NA values.")
+    cli::cli_abort("{.arg series_label} must not contain missing values.")
   }
 
   series_label <- unique(as.character(series_label))
 
   if (length(series_code) != length(series_label)) {
-    stop("tidyBdE> `series_label` and `series_code` must have the same length.")
+    cli::cli_abort(
+      "{.arg series_label} and {.arg series_code} must have the same length."
+    )
   }
 
   # Search the catalogs.
@@ -142,31 +138,28 @@ bde_series_load <- function(
 
   df_list <- lapply(series_code, function(x) {
     if (verbose) {
-      message("tidyBdE> Extracting series ", x, ".")
+      cli::cli_alert_info("Extracting series {.val {x}}.")
     }
 
-    # Identify the source file.
+    # Match the sequential code to the first catalog record available.
     csv_file <- all_catalogs[all_catalogs[[1]] == x, c(2, 3)]
 
     if (nrow(csv_file) == 0) {
-      message("tidyBdE> `series_code` not found in catalogs.")
+      cli::cli_alert_warning("{.arg series_code} was not found in catalogs.")
       tbl <- bde_hlp_return_null()
       return(tbl)
     }
 
-    # Select the first available record.
+    # Use the first available alias when a series appears in multiple tables.
     csv_file_name <- as.character(csv_file[1, 2])
     alias_serie <- as.character(csv_file[1, 1])
 
     if (verbose) {
-      message(
-        "tidyBdE> Downloading series ",
-        x,
-        " from file ",
-        csv_file_name,
-        " (alias ",
-        alias_serie,
-        ")."
+      cli::cli_alert_info(
+        paste0(
+          "Downloading series {.val {x}} from file ",
+          "{.file {csv_file_name}} (alias {.val {alias_serie}})."
+        )
       )
     }
 
@@ -188,13 +181,11 @@ bde_series_load <- function(
     }
     if (!(alias_serie %in% names(serie_file))) {
       if (verbose) {
-        message(
-          "tidyBdE> ",
-          "Series with alias '",
-          alias_serie,
-          "' is not available in ",
-          csv_file_name,
-          "."
+        cli::cli_alert_warning(
+          paste0(
+            "Series with alias {.val {alias_serie}} is not available in ",
+            "{.file {csv_file_name}}."
+          )
         )
       }
 
@@ -231,14 +222,14 @@ bde_series_load <- function(
 
   df_list <- df_list[has_date]
 
-  # Check the number of series and merge if needed.
+  # Return early when every requested series failed to load.
   if (length(df_list) == 0) {
     return(bde_hlp_return_null())
   }
 
-  # Convert to long format.
+  # Bind the successfully loaded series before final reshaping.
   end <- dplyr::bind_rows(df_list)
-  # Convert series names to factors for consistent plotting.
+  # Preserve the requested series order in plots.
   end$serie_name <- factor(end$serie_name, levels = unique(end$serie_name))
 
   if (out_format == "wide" || isTRUE(extract_metadata)) {
@@ -256,6 +247,7 @@ bde_series_load <- function(
 
 #' Load BdE full time series files
 #'
+#' @description
 #' Load a full BdE time series file.
 #'
 #' ## About BdE file naming
@@ -268,31 +260,28 @@ bde_series_load <- function(
 #' For that reason, [bde_series_load()] is more suitable for extracting
 #' specific time series.
 #'
-#' @export
-#' @encoding UTF-8
-#'
-#' @family series
-#'
-#' @param series_csv CSV file of a series, as defined in the field
+#' @param series_csv CSV file name for a series, as defined in the field
 #'   `Nombre del archivo con los valores de la serie` of the corresponding
 #'   catalog. See [bde_catalog_load()].
-#'
 #' @inheritParams bde_catalog_load
-#'
 #' @param parse_numeric Logical. If `TRUE`, the columns are parsed to
 #'   double (numeric) values. See **Note**.
-#'
 #' @param extract_metadata Logical. If `TRUE`, the output is the metadata of the
 #'   requested series.
 #'
-#' @return
-#' A [tibble][tibble::tbl_df] with a `Date` field and the aliases of the
-#' series fields as described in the catalogs. See [bde_catalog_load()].
+#' @return A [tibble][tibble::tbl_df] with a `Date` field and the aliases of
+#' the time series fields as described in the catalogs. See
+#' [bde_catalog_load()].
 #'
 #' @note
-#' This function tries to coerce the columns to numbers. For some series, a
-#' warning may be displayed if the parser fails. You can override the default
+#' This function tries to coerce the columns to numbers. For some time series,
+#' a warning may be displayed if the parser fails. You can override the default
 #' behavior with `parse_numeric = FALSE`.
+#'
+#' @family series
+#'
+#' @export
+#' @encoding UTF-8
 #'
 #' @examplesIf bde_check_access()
 #' \donttest{
@@ -324,14 +313,14 @@ bde_series_full_load <- function(
 
   pp <- substr(series_csv, 1, 2)
 
-  # Resolve the cache directory.
+  # Resolve the cache directory for the series family.
   cache_dir <- bde_hlp_cachedir(
     cache_dir = cache_dir,
     verbose = verbose,
     suffix = pp
   )
 
-  # Create the directory if it does not exist.
+  # Ensure downloads have a family-specific destination.
   if (!dir.exists(cache_dir)) {
     dir.create(cache_dir, recursive = TRUE)
   }
@@ -369,20 +358,20 @@ bde_series_full_load <- function(
     }
   } else {
     if (verbose) {
-      message("tidyBdE> Reading file ", serie_file, " from cache.")
+      cli::cli_alert_success("Reading file {.file {serie_file}} from cache.")
     }
   }
 
-  # Catch errors.
+  # Reject empty files before encoding detection.
   # nocov start
   r <- readLines(local_file, warn = FALSE, n = 1000)
   if (length(r) == 0) {
-    message("tidyBdE> File ", local_file, " is not valid.")
+    cli::cli_alert_warning("File {.file {local_file}} is not valid.")
     return(invisible())
   }
   # nocov end
 
-  # Load the series.
+  # Read the raw CSV after detecting its encoding.
   enc <- readr::guess_encoding(local_file)[[1]][[1]]
 
   serie_load <- suppressWarnings(
@@ -398,16 +387,16 @@ bde_series_full_load <- function(
 
   serie_load <- tibble::as_tibble(serie_load)
 
-  # Header names are in the third row.
+  # BdE series files store column names in the third row.
   newnames <- as.character(serie_load[3, ])
   newnames[1] <- "Date"
 
   names(serie_load) <- newnames
 
-  # Extract metadata from the first six rows.
+  # Preserve the file-level metadata rows.
   meta_serie <- serie_load[seq_len(6), ]
 
-  # Add source and notes.
+  # Keep source and notes with the metadata used for aliases.
   source_notes <- serie_load[serie_load[[1]] %in% c("FUENTE", "NOTAS"), ]
 
   if (extract_metadata) {
@@ -416,7 +405,7 @@ bde_series_full_load <- function(
 
   meta_serie <- dplyr::bind_rows(meta_serie, source_notes)
 
-  # Keep the remaining rows as data.
+  # Keep observation rows after removing metadata.
   data_serie <- serie_load[-seq_len(6), ]
 
   data_serie <- data_serie[
@@ -426,10 +415,10 @@ bde_series_full_load <- function(
   newnames_data <- as.character(meta_serie[4, ])
   newnames_data[1] <- "Date"
 
-  # Parse dates.
+  # Parse date fields before numeric conversion.
   if (parse_dates) {
     if (verbose) {
-      message("tidyBdE> Parsing dates.")
+      cli::cli_alert_info("Parsing date columns.")
     }
     date_fields <- names(data_serie)[grep(
       "Date",
@@ -446,9 +435,9 @@ bde_series_full_load <- function(
 
   if (parse_numeric) {
     if (verbose) {
-      message("tidyBdE> Parsing fields as double.")
+      cli::cli_alert_info("Parsing numeric fields as doubles.")
     }
-    # Convert fields to double precision numbers.
+    # Preserve dates while converting observations to double precision.
     data_serie <- bde_hlp_todouble(data_serie, preserve = "Date")
   }
   data_serie

--- a/R/superseded.R
+++ b/R/superseded.R
@@ -5,18 +5,18 @@
 #'
 #' These palettes are superseded. Use [bde_tidy_palettes()] instead.
 #'
-#' @return A color palette function.
-#'
 #' @param ... Additional arguments.
 #'
-#' @name bde_vivid_pal
+#' @return A color palette function.
+#'
 #' @rdname bde_pals
+#' @name bde_vivid_pal
 #'
 #' @export
 #' @encoding UTF-8
 #' @keywords internal
-#' @examples
 #'
+#' @examples
 #' # Show the vivid palette.
 #' scales::show_col(bde_vivid_pal()(6), labels = FALSE)
 #'
@@ -36,9 +36,9 @@ bde_vivid_pal <- function(...) {
 }
 
 #' @rdname bde_pals
-#' @keywords internal
 #' @export
 #' @encoding UTF-8
+#' @keywords internal
 bde_rose_pal <- function(...) {
   if (requireNamespace("lifecycle", quietly = TRUE)) {
     lifecycle::deprecate_soft("0.3.5", "bde_rose_pal()", "bde_tidy_palettes()")

--- a/R/theme_tidybde.R
+++ b/R/theme_tidybde.R
@@ -3,21 +3,21 @@
 #' @description
 #' Custom \CRANpkg{ggplot2} theme based on BdE publications.
 #'
-#' @family bde_plot
-#'
-#' @export
-#' @encoding UTF-8
-#'
-#' @return A \CRANpkg{ggplot2} theme object.
-#'
 #' @inheritDotParams ggplot2::theme_classic
-#'
-#' @seealso [ggplot2::theme_classic()]
 #'
 #' @details
 #' This theme is based on [ggplot2::theme_classic()].
 #'
+#' @return A \CRANpkg{ggplot2} theme object.
+#'
+#' @seealso [ggplot2::theme_classic()]
+#'
+#' @family bde_plot
+#'
 #' @importFrom ggplot2 %+replace% rel margin
+#' @export
+#' @encoding UTF-8
+#'
 #' @examplesIf bde_check_access()
 #' \donttest{
 #' library(ggplot2)

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,21 +1,9 @@
 #' Parse dates from strings
 #'
-#' Parse strings representing dates with [as.Date()].
-#'
-#' @export
-#' @encoding UTF-8
-#'
-#' @family utils
-#'
-#' @return A vector of [`Date`][as.Date()] values.
-#'
-#' @seealso [as.Date()]
-#'
-#' @param dates_to_parse Character vector of dates to parse.
-#'
 #' @description
-#' This function is tailored to date formats used in this package and may fail
-#' with other datasets. See **Examples** for formats that are supported.
+#' Parse strings representing dates with [as.Date()]. This function is tailored
+#' to date formats used in this package and may fail with other datasets. See
+#' **Examples** for formats that are supported.
 #'
 #' ## Date formats
 #'
@@ -44,6 +32,17 @@
 #'
 #' knitr::kable(dates)
 #' ```
+#'
+#' @param dates_to_parse Character vector of dates to parse.
+#'
+#' @return A vector of [`Date`][as.Date()] values.
+#'
+#' @seealso [as.Date()]
+#'
+#' @family utils
+#'
+#' @export
+#' @encoding UTF-8
 #'
 #' @examples
 #' # Supported formats.
@@ -117,17 +116,17 @@ bde_parse_dates <- function(dates_to_parse) {
 #'
 #' @param cache_dir Path to a cache directory.
 #' @param verbose Logical indicating whether to display informative messages.
-#' @param suffix An optional suffix to append to the path.
+#' @param suffix Optional suffix to append to the path.
 #'
 #' @noRd
 bde_hlp_cachedir <- function(cache_dir = NULL, verbose = FALSE, suffix = NULL) {
-  # Resolve the cache directory.
+  # Prefer an explicit cache directory, then an option, then a temp directory.
   if (is.null(cache_dir)) {
-    # Check whether the directory is set via global options.
+    # Respect the global cache option when no directory is supplied.
     cache_dir <- getOption("bde_cache_dir", NULL)
 
     if (is.null(cache_dir)) {
-      # Fall back to a temporary directory.
+      # Keep default caching disposable when no cache is configured.
       cache_dir <- tempdir()
 
       if (!is.null(suffix)) {
@@ -135,36 +134,36 @@ bde_hlp_cachedir <- function(cache_dir = NULL, verbose = FALSE, suffix = NULL) {
       }
 
       if (verbose) {
-        message("tidyBdE> Caching in temporary directory ", cache_dir, ".")
+        cli::cli_alert_info(
+          "Using temporary cache directory {.path {cache_dir}}."
+        )
       }
       return(cache_dir)
     } else {
-      # Use the cache directory from global options.
+      # Report the configured cache location when requested.
       if (verbose) {
-        message(
-          "tidyBdE> Cache directory detected in options: ",
-          cache_dir,
-          "."
+        cli::cli_alert_info(
+          "Using cache directory from options: {.path {cache_dir}}."
         )
       }
     }
   }
 
-  # Append the suffix when provided.
+  # Keep family-specific series files in a stable subdirectory.
   if (!is.null(suffix)) {
     cache_dir <- file.path(gsub(file.path("", suffix), "", cache_dir), suffix)
   }
 
   if (dir.exists(cache_dir)) {
     if (verbose) {
-      message("tidyBdE> Cache directory is ", cache_dir, ".")
+      cli::cli_alert_success("Using cache directory {.path {cache_dir}}.")
     }
     return(cache_dir)
   }
 
   dir.create(cache_dir, recursive = TRUE)
   if (verbose) {
-    message("tidyBdE> Cache directory created at ", cache_dir, ".")
+    cli::cli_alert_success("Created cache directory {.path {cache_dir}}.")
   }
   cache_dir
 }
@@ -180,7 +179,7 @@ bde_hlp_cachedir <- function(cache_dir = NULL, verbose = FALSE, suffix = NULL) {
 #' @noRd
 bde_hlp_download <- function(url, local_file, verbose) {
   if (verbose) {
-    message("tidyBdE> Downloading file from ", url, ".")
+    cli::cli_alert_info("Downloading file from {.url {url}}.")
   }
 
   err_dwnload <- tryCatch(
@@ -191,23 +190,23 @@ bde_hlp_download <- function(url, local_file, verbose) {
     }
   )
   # nocov end
-  # Attempt a second download if the first fails.
+  # Retry once because intermittent warnings are common for remote files.
 
   # nocov start
   if (isTRUE(err_dwnload)) {
     if (verbose) {
-      message("tidyBdE> Trying again.")
+      cli::cli_alert_warning("Download failed. Trying again.")
     }
 
     err_dwnload <- tryCatch(
       download.file(url, local_file, quiet = isFALSE(verbose), mode = "wb"),
       # nocov start
       warning = function(e) {
-        message(
-          "tidyBdE> URL ",
-          url,
-          " is not reachable. ",
-          "If you think this is a bug, consider opening an issue."
+        cli::cli_alert_warning(
+          paste0(
+            "URL {.url {url}} is not reachable. ",
+            "If this looks like a bug, please open an issue."
+          )
         )
         TRUE
       }
@@ -215,7 +214,7 @@ bde_hlp_download <- function(url, local_file, verbose) {
   }
   # nocov end
 
-  # Return FALSE if a warning is encountered.
+  # Signal download failure without raising an error.
   if (isTRUE(err_dwnload)) {
     return(FALSE)
     # nocov end
@@ -275,15 +274,19 @@ bde_hlp_todouble <- function(tbl, preserve = "") {
 
 #' Return an empty tibble with an informative message
 #'
+#' @param msg Message to display before returning the empty tibble.
+#'
 #' @return A [tibble][tibble::tbl_df].
 #'
 #' @examples
-#'
 #' bde_hlp_return_null()
+#'
 #' @noRd
-bde_hlp_return_null <- function(msg = "Offline. Returning an empty tibble.") {
+bde_hlp_return_null <- function(
+  msg = "BdE is offline. Returning an empty tibble."
+) {
   # nocov start
-  message(paste0("tidyBdE> ", msg))
+  cli::cli_alert_info(msg)
   tbl <- tibble::tibble(x = NULL)
   tbl
   # nocov end

--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ developed.](https://www.repostatus.org/badges/latest/active.svg)](https://www.re
 
 **tidyBdE** is an **R** package that retrieves data from [Banco de
 España](https://www.bde.es/webbe/en/estadisticas/recursos/descargas-completas.html).
-Data are returned as a [tibble](https://tibble.tidyverse.org/), and the
-package automatically detects the format of each time series (dates,
-characters and numbers).
+Data are returned as [**tibble**](https://tibble.tidyverse.org/)
+objects. The package automatically detects the format of each time
+series field, including dates, character fields and numeric fields.
 
 ## Installation
 
@@ -37,13 +37,13 @@ Install **tidyBdE** from
 install.packages("tidyBdE")
 ```
 
-You can install the development version of **tidyBdE** with:
+Install the development version of **tidyBdE** from GitHub with:
 
 ``` r
 pak::pak("ropenspain/tidyBdE")
 ```
 
-Alternatively, you can install **tidyBdE** from the
+Alternatively, install **tidyBdE** from
 [r-universe](https://ropenspain.r-universe.dev/tidyBdE):
 
 ``` r
@@ -60,11 +60,11 @@ install.packages(
 ## Examples
 
 Banco de España (**BdE**) provides several time series, either produced
-by the institution itself or compiled from other sources, such as
+by the institution or compiled from other sources, such as
 [Eurostat](https://ec.europa.eu/eurostat) or [INE](https://www.ine.es/).
 
-The basic entry point for searching series is the time series catalog.
-You can search for series by name:
+The basic entry point for searching time series is the catalog. You can
+search for time series by name:
 
 ``` r
 library(tidyBdE)
@@ -92,18 +92,18 @@ xr_gbp |>
 Table 1: Search results
 </p>
 
-**Note:** BdE metadata is currently provided in Spanish only, so search
-terms must be provided in Spanish to retrieve results. The institution
-is working on an English version.
+**Note:** BdE metadata is currently available in Spanish only, so search
+terms must be in Spanish to retrieve results. The institution is working
+on an English version.
 
-After finding a series, you can load the GBP/EUR exchange rate using the
-sequential number reference (`Numero_secuencial`):
+After finding a time series, you can load the GBP/EUR exchange rate
+using the sequential number reference (`Numero_secuencial`):
 
 ``` r
 seq_number <- xr_gbp |>
   # Select the first record.
   slice(1) |>
-  # Get the series ID.
+  # Get the series code.
   select(Numero_secuencial) |>
   # Convert to numeric.
   as.double()
@@ -160,8 +160,9 @@ ggplot(time_series, aes(x = Date, y = EUR_GBP_XR)) +
 <img src="man/figures/README-chart-1.png" style="width:100.0%"
 alt="EUR/GBP Exchange Rate (2010-2020)" />
 
-The package also provides convenience functions for selected
-macroeconomic series, so you do not need to search for them manually:
+The package also provides convenience functions for selected Spanish
+macroeconomic indicators, so you do not need to search for them
+manually:
 
 ``` r
 # Data in long format.
@@ -189,26 +190,25 @@ alt="Spanish Economic Indicators (2010-2019)" />
 
 ### Palettes
 
-Three custom palettes are available, based on those used by BdE in some
-publications.
+Three custom palettes are available. They are based on colors used by
+BdE in some publications.
 
-Apply these palettes to **ggplot2** plots using the scale functions
-provided in the package (see
-`help("scale_color_bde_d", package = "tidyBdE")`).
+Apply these palettes to **ggplot2** plots with the scale functions
+provided by the package. See
+`help("scale_color_bde_d", package = "tidyBdE")`.
 
 ### A note on caching
 
-You can use **tidyBdE** to create a local cache by setting the following
-option:
+Create a local cache by setting the following option:
 
 ``` r
 options(bde_cache_dir = "./path/to/location")
 ```
 
 When this option is set, **tidyBdE** looks for cached files in the
-`bde_cache_dir` directory and loads them, speeding up data retrieval.
+`bde_cache_dir` directory and loads them to speed up data retrieval.
 
-You can update the data after monthly or quarterly releases with the
+Update cached data after monthly or quarterly releases with the
 following commands:
 
 ``` r
@@ -228,7 +228,7 @@ España.
 
 <p>
 
-H. Herrero D (2026). <em>tidyBdE: Retrieve Data from Banco de
+H. Herrero D (2026). <em>tidyBdE: Retrieve Time Series Data from Banco de
 España</em>.
 <a href="https://doi.org/10.32614/CRAN.package.tidyBdE">doi:10.32614/CRAN.package.tidyBdE</a>.
 <a href="https://ropenspain.github.io/tidyBdE/">https://ropenspain.github.io/tidyBdE/</a>.
@@ -237,7 +237,7 @@ España</em>.
 A BibTeX entry for LaTeX users is:
 
     @Manual{R-tidyBdE,
-      title = {{tidyBdE}: Retrieve Data from Banco de España},
+      title = {{tidyBdE}: Retrieve Time Series Data from Banco de España},
       doi = {10.32614/CRAN.package.tidyBdE},
       author = {Diego {H. Herrero}},
       year = {2026},

--- a/README.qmd
+++ b/README.qmd
@@ -38,9 +38,9 @@ developed.](https://www.repostatus.org/badges/latest/active.svg)](https://www.re
 
 **tidyBdE** is an **R** package that retrieves data from [Banco de
 España](https://www.bde.es/webbe/en/estadisticas/recursos/descargas-completas.html).
-Data are returned as a [tibble](https://tibble.tidyverse.org/), and the
-package automatically detects the format of each time series (dates, characters
-and numbers).
+Data are returned as [**tibble**](https://tibble.tidyverse.org/) objects. The
+package automatically detects the format of each time series field, including
+dates, character fields and numeric fields.
 
 ## Installation
 
@@ -51,14 +51,14 @@ Install **tidyBdE** from [CRAN](https://CRAN.R-project.org/package=tidyBdE):
 install.packages("tidyBdE")
 ```
 
-You can install the development version of **tidyBdE** with:
+Install the development version of **tidyBdE** from GitHub with:
 
 ```{r}
 #| eval: false
 pak::pak("ropenspain/tidyBdE")
 ```
 
-Alternatively, you can install **tidyBdE** from the
+Alternatively, install **tidyBdE** from
 [r-universe](https://ropenspain.r-universe.dev/tidyBdE):
 
 ```{r}
@@ -76,11 +76,11 @@ install.packages(
 ## Examples
 
 Banco de España (**BdE**) provides several time series, either produced by the
-institution itself or compiled from other sources, such as
+institution or compiled from other sources, such as
 [Eurostat](https://ec.europa.eu/eurostat) or [INE](https://www.ine.es/).
 
-The basic entry point for searching series is the time series catalog. You can
-search for series by name:
+The basic entry point for searching time series is the catalog. You can search
+for time series by name:
 
 ```{r}
 #| label: search
@@ -111,11 +111,11 @@ xr_gbp |>
 cat("<p class=\"caption\">Table 1: Search results</p>")
 ```
 
-**Note:** BdE metadata is currently provided in Spanish only, so search terms
-must be provided in Spanish to retrieve results. The institution is working on
-an English version.
+**Note:** BdE metadata is currently available in Spanish only, so search terms
+must be in Spanish to retrieve results. The institution is working on an
+English version.
 
-After finding a series, you can load the GBP/EUR exchange rate using the
+After finding a time series, you can load the GBP/EUR exchange rate using the
 sequential number reference (`Numero_secuencial`):
 
 ```{r}
@@ -123,7 +123,7 @@ sequential number reference (`Numero_secuencial`):
 seq_number <- xr_gbp |>
   # Select the first record.
   slice(1) |>
-  # Get the series ID.
+  # Get the series code.
   select(Numero_secuencial) |>
   # Convert to numeric.
   as.double()
@@ -138,7 +138,8 @@ time_series
 
 ### Plots
 
-The package also provides a custom **ggplot2** theme based on BdE publications:
+The package also provides a custom **ggplot2** theme based on BdE
+publications:
 
 ```{r}
 #| label: chart
@@ -165,8 +166,8 @@ ggplot(time_series, aes(x = Date, y = EUR_GBP_XR)) +
   theme_tidybde()
 ```
 
-The package also provides convenience functions for selected macroeconomic
-series, so you do not need to search for them manually:
+The package also provides convenience functions for selected Spanish
+macroeconomic indicators, so you do not need to search for them manually:
 
 ```{r}
 #| label: macroseries
@@ -194,25 +195,24 @@ ggplot(plotseries, aes(x = Date, y = serie_value)) +
 
 ### Palettes
 
-Three custom palettes are available, based on those used by BdE in some
-publications.
+Three custom palettes are available. They are based on colors used by BdE in
+some publications.
 
-Apply these palettes to **ggplot2** plots using the scale functions provided in
-the package (see `help("scale_color_bde_d", package = "tidyBdE")`).
+Apply these palettes to **ggplot2** plots with the scale functions provided by
+the package. See `help("scale_color_bde_d", package = "tidyBdE")`.
 
 ### A note on caching
 
-You can use **tidyBdE** to create a local cache by setting the following
-option:
+Create a local cache by setting the following option:
 
 ``` r
 options(bde_cache_dir = "./path/to/location")
 ```
 
 When this option is set, **tidyBdE** looks for cached files in the
-`bde_cache_dir` directory and loads them, speeding up data retrieval.
+`bde_cache_dir` directory and loads them to speed up data retrieval.
 
-You can update the data after monthly or quarterly releases with the following
+Update cached data after monthly or quarterly releases with the following
 commands:
 
 ```{r}

--- a/codemeta.json
+++ b/codemeta.json
@@ -8,7 +8,7 @@
   "codeRepository": "https://github.com/rOpenSpain/tidyBdE",
   "issueTracker": "https://github.com/rOpenSpain/tidyBdE/issues",
   "license": "https://spdx.org/licenses/GPL-3.0",
-  "version": "0.6.1",
+  "version": "0.6.1.9000",
   "programmingLanguage": {
     "@type": "ComputerLanguage",
     "name": "R",
@@ -108,6 +108,18 @@
     },
     "2": {
       "@type": "SoftwareApplication",
+      "identifier": "cli",
+      "name": "cli",
+      "provider": {
+        "@id": "https://cran.r-project.org",
+        "@type": "Organization",
+        "name": "Comprehensive R Archive Network (CRAN)",
+        "url": "https://cran.r-project.org"
+      },
+      "sameAs": "https://CRAN.R-project.org/package=cli"
+    },
+    "3": {
+      "@type": "SoftwareApplication",
       "identifier": "dplyr",
       "name": "dplyr",
       "version": ">= 0.7.0",
@@ -119,7 +131,7 @@
       },
       "sameAs": "https://CRAN.R-project.org/package=dplyr"
     },
-    "3": {
+    "4": {
       "@type": "SoftwareApplication",
       "identifier": "ggplot2",
       "name": "ggplot2",
@@ -132,7 +144,7 @@
       },
       "sameAs": "https://CRAN.R-project.org/package=ggplot2"
     },
-    "4": {
+    "5": {
       "@type": "SoftwareApplication",
       "identifier": "readr",
       "name": "readr",
@@ -145,7 +157,7 @@
       },
       "sameAs": "https://CRAN.R-project.org/package=readr"
     },
-    "5": {
+    "6": {
       "@type": "SoftwareApplication",
       "identifier": "scales",
       "name": "scales",
@@ -158,7 +170,7 @@
       },
       "sameAs": "https://CRAN.R-project.org/package=scales"
     },
-    "6": {
+    "7": {
       "@type": "SoftwareApplication",
       "identifier": "tibble",
       "name": "tibble",
@@ -171,7 +183,7 @@
       },
       "sameAs": "https://CRAN.R-project.org/package=tibble"
     },
-    "7": {
+    "8": {
       "@type": "SoftwareApplication",
       "identifier": "tidyr",
       "name": "tidyr",
@@ -183,7 +195,7 @@
       },
       "sameAs": "https://CRAN.R-project.org/package=tidyr"
     },
-    "8": {
+    "9": {
       "@type": "SoftwareApplication",
       "identifier": "utils",
       "name": "utils"
@@ -193,7 +205,7 @@
   "applicationCategory": "Macroeconomics",
   "isPartOf": "https://ropenspain.es/",
   "keywords": ["api", "bde", "cran", "ggplot2", "macroeconomics", "r", "r-package", "ropenspain", "rstats", "series-data", "spain"],
-  "fileSize": "297.099KB",
+  "fileSize": "306.309KB",
   "citation": [
     {
       "@type": "SoftwareSourceCode",

--- a/codemeta.json
+++ b/codemeta.json
@@ -3,7 +3,7 @@
   "@type": "SoftwareSourceCode",
   "identifier": "tidyBdE",
   "description": "Tools for retrieving time series data from 'Banco de España' ('BdE') as 'tibble' objects. 'Banco de España' is the national central bank and, within the framework of the Single Supervisory Mechanism ('SSM'), the supervisor of the Spanish banking system alongside the European Central Bank. This package is not sponsored, endorsed or administered by 'Banco de España'.",
-  "name": "tidyBdE: Retrieve Data from 'Banco de España'",
+  "name": "tidyBdE: Retrieve Time Series Data from 'Banco de España'",
   "relatedLink": ["https://ropenspain.github.io/tidyBdE/", "https://CRAN.R-project.org/package=tidyBdE"],
   "codeRepository": "https://github.com/rOpenSpain/tidyBdE",
   "issueTracker": "https://github.com/rOpenSpain/tidyBdE/issues",
@@ -205,7 +205,7 @@
           "familyName": "H. Herrero"
         }
       ],
-      "name": "{tidyBdE}: Retrieve Data from Banco de España",
+      "name": "{tidyBdE}: Retrieve Time Series Data from Banco de España",
       "identifier": "10.32614/CRAN.package.tidyBdE",
       "url": "https://ropenspain.github.io/tidyBdE/",
       "@id": "https://doi.org/10.32614/CRAN.package.tidyBdE",

--- a/index.md
+++ b/index.md
@@ -1,6 +1,6 @@
 
 
-<!-- README.md is generated from README.qmd. Please edit that file -->
+<!-- index.md is generated from index.qmd. Please edit that file -->
 
 # tidyBdE <a href="https://ropenspain.github.io/tidyBdE/"><img src="man/figures/logo.png" alt="tidyBdE website" align="right" height="139"/></a>
 
@@ -28,10 +28,17 @@ Data are returned as [**tibble**](https://tibble.tidyverse.org/)
 objects. The package automatically detects the format of each time
 series field, including dates, character fields and numeric fields.
 
-> [!IMPORTANT]
->
-> This package is not sponsored, endorsed or administered by Banco de
-> España.
+<div class="callout callout-style-default callout-important callout-titled">
+<div class="callout-header d-flex align-content-center">
+<div class="callout-icon-container"><i class="callout-icon"></i></div>
+<div class="callout-title-container flex-fill">A note on performance</div></div>
+<div class="callout-body-container callout-body">
+
+This package is not sponsored, endorsed or administered by Banco de
+España.
+
+</div>
+</div>
 
 ## Installation
 
@@ -97,11 +104,19 @@ xr_gbp |>
 Table 1: Search results
 </p>
 
-> [!NOTE]
->
-> BdE metadata is currently available in Spanish only, so search terms
-> must be in Spanish to retrieve results. The institution is working on
-> an English version.
+<div class="callout callout-style-default callout-note callout-titled">
+<div class="callout-header d-flex align-content-center">
+<div class="callout-icon-container"><i class="callout-icon"></i></div>
+<div class="callout-title-container flex-fill">About the screenshots</div>
+</div>
+<div class="callout-body-container callout-body">
+
+BdE metadata is currently available in Spanish only, so search terms
+must be in Spanish to retrieve results. The institution is working on an
+English version.
+
+</div>
+</div>
 
 After finding a time series, you can load the GBP/EUR exchange rate
 using the sequential number reference (`Numero_secuencial`):

--- a/index.qmd
+++ b/index.qmd
@@ -14,7 +14,7 @@ knitr:
     out.width: "100%"
 ---
 
-<!-- README.md is generated from README.qmd. Please edit that file -->
+<!-- index.md is generated from index.qmd. Please edit that file -->
 
 # tidyBdE <a href="https://ropenspain.github.io/tidyBdE/"><img src="man/figures/logo.png" alt="tidyBdE website" align="right" height="139"/></a>
 
@@ -42,9 +42,20 @@ Data are returned as [**tibble**](https://tibble.tidyverse.org/) objects. The
 package automatically detects the format of each time series field, including
 dates, character fields and numeric fields.
 
-::: callout-important
+```{=html}
+<div class="callout callout-style-default callout-important callout-titled">
+<div class="callout-header d-flex align-content-center">
+<div class="callout-icon-container"><i class="callout-icon"></i></div>
+<div class="callout-title-container flex-fill">A note on performance</div></div>
+<div class="callout-body-container callout-body">
+```
+
 This package is not sponsored, endorsed or administered by Banco de España.
-:::
+
+```{=html}
+</div>
+</div>
+```
 
 ## Installation
 
@@ -115,10 +126,22 @@ xr_gbp |>
 cat("<p class=\"caption\">Table 1: Search results</p>")
 ```
 
-::: callout-note
+```{=html}
+<div class="callout callout-style-default callout-note callout-titled">
+<div class="callout-header d-flex align-content-center">
+<div class="callout-icon-container"><i class="callout-icon"></i></div>
+<div class="callout-title-container flex-fill">About the screenshots</div>
+</div>
+<div class="callout-body-container callout-body">
+```
+
 BdE metadata is currently available in Spanish only, so search terms must be in
 Spanish to retrieve results. The institution is working on an English version.
-:::
+
+```{=html}
+</div>
+</div>
+```
 
 After finding a time series, you can load the GBP/EUR exchange rate using the
 sequential number reference (`Numero_secuencial`):

--- a/inst/schemaorg.json
+++ b/inst/schemaorg.json
@@ -16,7 +16,7 @@
       },
       "description": "Tools for retrieving time series data from 'Banco de España' ('BdE') as 'tibble' objects. 'Banco de España' is the national central bank and, within the framework of the Single Supervisory Mechanism ('SSM'), the supervisor of the Spanish banking system alongside the European Central Bank. This package is not sponsored, endorsed or administered by 'Banco de España'.",
       "license": "https://spdx.org/licenses/GPL-3.0",
-      "name": "tidyBdE: Retrieve Data from 'Banco de España'",
+      "name": "tidyBdE: Retrieve Time Series Data from 'Banco de España'",
       "programmingLanguage": {
         "type": "ComputerLanguage",
         "name": "R",
@@ -39,7 +39,7 @@
         "familyName": "H. Herrero",
         "givenName": "Diego"
       },
-      "name": "{tidyBdE}: Retrieve Data from Banco de España"
+      "name": "{tidyBdE}: Retrieve Time Series Data from Banco de España"
     }
   ]
 }

--- a/inst/schemaorg.json
+++ b/inst/schemaorg.json
@@ -29,7 +29,7 @@
         "url": "https://cran.r-project.org"
       },
       "runtimePlatform": "R version 4.6.0 (2026-04-24 ucrt)",
-      "version": "0.6.1"
+      "version": "0.6.1.9000"
     },
     {
       "id": "https://doi.org/10.32614/CRAN.package.tidyBdE",

--- a/man/bde_catalog_load.Rd
+++ b/man/bde_catalog_load.Rd
@@ -5,7 +5,7 @@
 \alias{bde_catalog_load}
 \title{Load BdE catalog metadata}
 \source{
-\href{https://www.bde.es/webbe/en/estadisticas/recursos/descargas-completas.html}{time series bulk data download}.
+\href{https://www.bde.es/webbe/en/estadisticas/recursos/descargas-completas.html}{Time series bulk data download}.
 }
 \usage{
 bde_catalog_load(
@@ -23,8 +23,8 @@ catalog. See \strong{Details}.}
 \item{parse_dates}{Logical. If \code{TRUE}, date columns are parsed with
 \code{\link[=bde_parse_dates]{bde_parse_dates()}}.}
 
-\item{cache_dir}{A path to a cache directory. The directory can also be set
-with options using \code{options(bde_cache_dir = "path/to/dir")}.}
+\item{cache_dir}{Path to a cache directory. The directory can also be set
+with \code{options(bde_cache_dir = "path/to/dir")}.}
 
 \item{update_cache}{Logical. If \code{TRUE}, the requested file is refreshed in
 \code{cache_dir}.}

--- a/man/bde_catalog_search.Rd
+++ b/man/bde_catalog_search.Rd
@@ -20,8 +20,8 @@ catalog. See \strong{Details}.}
 \code{\link[=bde_parse_dates]{bde_parse_dates()}}.}
     \item{\code{update_cache}}{Logical. If \code{TRUE}, the requested file is refreshed in
 \code{cache_dir}.}
-    \item{\code{cache_dir}}{A path to a cache directory. The directory can also be set
-with options using \code{options(bde_cache_dir = "path/to/dir")}.}
+    \item{\code{cache_dir}}{Path to a cache directory. The directory can also be set
+with \code{options(bde_cache_dir = "path/to/dir")}.}
     \item{\code{verbose}}{Logical. If \code{TRUE}, display information useful for debugging.}
   }}
 }
@@ -32,8 +32,8 @@ A \link[tibble:tbl_df]{tibble} object with the results of the query.
 Search BdE time series catalog metadata for keywords.
 }
 \details{
-\strong{Note:} BdE metadata is currently provided in Spanish only. Therefore,
-search terms must be provided in Spanish to retrieve results.
+\strong{Note:} BdE metadata is currently available in Spanish only. Therefore,
+search terms must be in Spanish to retrieve results.
 
 This function uses \code{\link[base:grep]{base::grep()}} to find matches in the catalogs. You can
 pass \link[base:regex]{regular expressions} to broaden the search.

--- a/man/bde_catalog_update.Rd
+++ b/man/bde_catalog_update.Rd
@@ -5,7 +5,7 @@
 \alias{bde_catalog_update}
 \title{Update BdE catalog files}
 \source{
-\href{https://www.bde.es/webbe/en/estadisticas/recursos/descargas-completas.html}{time series bulk data download}.
+\href{https://www.bde.es/webbe/en/estadisticas/recursos/descargas-completas.html}{Time series bulk data download}.
 }
 \usage{
 bde_catalog_update(
@@ -18,8 +18,8 @@ bde_catalog_update(
 \item{catalog}{A single catalog identifier to update, or \code{"ALL"} to update
 every catalog. See \strong{Details}.}
 
-\item{cache_dir}{A path to a cache directory. The directory can also be set
-with options using \code{options(bde_cache_dir = "path/to/dir")}.}
+\item{cache_dir}{Path to a cache directory. The directory can also be set
+with \code{options(bde_cache_dir = "path/to/dir")}.}
 
 \item{verbose}{Logical. If \code{TRUE}, display information useful for debugging.}
 }

--- a/man/bde_ind_db.Rd
+++ b/man/bde_ind_db.Rd
@@ -10,8 +10,8 @@ A \link[tibble:tbl_df]{tibble} of 9 rows and
 7 columns with the following fields:
 
 \describe{
-\item{tidyBdE_fun}{Function name, see \link{bde_indicators}.}
-\item{Numero_secuencial}{Series code, see \code{\link[=bde_series_load]{bde_series_load()}}.}
+\item{tidyBdE_fun}{Function name. See \link{bde_indicators}.}
+\item{Numero_secuencial}{Series code. See \code{\link[=bde_series_load]{bde_series_load()}}.}
 \item{Descripcion_de_la_serie}{Description of the series in Spanish.}
 \item{Fecha_de_la_primera_observacion}{Starting date of the indicator.}
 \item{Fecha_de_la_ultima_observacion}{Most recent date available.}

--- a/man/bde_indicators.Rd
+++ b/man/bde_indicators.Rd
@@ -40,8 +40,8 @@ to the extracted series.}
 \item{...}{
   Arguments passed on to \code{\link{bde_series_load}}
   \describe{
-    \item{\code{out_format}}{The format to return, either \code{"wide"} or \code{"long"}.
-See \strong{Value} for details and the \strong{Examples} section.}
+    \item{\code{out_format}}{The format to return, either \code{"wide"} or \code{"long"}. See
+\strong{Value} for details and the \strong{Examples} section.}
     \item{\code{parse_numeric}}{Logical. If \code{TRUE}, the columns are parsed to
 double (numeric) values. See \strong{Note}.}
     \item{\code{extract_metadata}}{Logical. If \code{TRUE}, the output is the metadata of the
@@ -50,8 +50,8 @@ requested series.}
 \code{\link[=bde_parse_dates]{bde_parse_dates()}}.}
     \item{\code{update_cache}}{Logical. If \code{TRUE}, the requested file is refreshed in
 \code{cache_dir}.}
-    \item{\code{cache_dir}}{A path to a cache directory. The directory can also be set
-with options using \code{options(bde_cache_dir = "path/to/dir")}.}
+    \item{\code{cache_dir}}{Path to a cache directory. The directory can also be set
+with \code{options(bde_cache_dir = "path/to/dir")}.}
     \item{\code{verbose}}{Logical. If \code{TRUE}, display information useful for debugging.}
   }}
 }

--- a/man/bde_pals.Rd
+++ b/man/bde_pals.Rd
@@ -22,7 +22,6 @@ A color palette function.
 These palettes are superseded. Use \code{\link[=bde_tidy_palettes]{bde_tidy_palettes()}} instead.
 }
 \examples{
-
 # Show the vivid palette.
 scales::show_col(bde_vivid_pal()(6), labels = FALSE)
 

--- a/man/bde_parse_dates.Rd
+++ b/man/bde_parse_dates.Rd
@@ -14,8 +14,9 @@ bde_parse_dates(dates_to_parse)
 A vector of \code{\link[=as.Date]{Date}} values.
 }
 \description{
-This function is tailored to date formats used in this package and may fail
-with other datasets. See \strong{Examples} for formats that are supported.
+Parse strings representing dates with \code{\link[=as.Date]{as.Date()}}. This function is tailored
+to date formats used in this package and may fail with other datasets. See
+\strong{Examples} for formats that are supported.
 \subsection{Date formats}{\tabular{lll}{
    \strong{FREQUENCY} \tab \strong{FORMAT} \tab \strong{EXAMPLES} \cr
    \strong{Daily / Business day} \tab DD MMMMYYYY \tab \emph{02 FEB2019} \cr
@@ -26,9 +27,6 @@ with other datasets. See \strong{Examples} for formats that are supported.
 }
 
 }
-}
-\details{
-Parse strings representing dates with \code{\link[=as.Date]{as.Date()}}.
 }
 \examples{
 # Supported formats.

--- a/man/bde_series_full_load.Rd
+++ b/man/bde_series_full_load.Rd
@@ -16,7 +16,7 @@ bde_series_full_load(
 )
 }
 \arguments{
-\item{series_csv}{CSV file of a series, as defined in the field
+\item{series_csv}{CSV file name for a series, as defined in the field
 \verb{Nombre del archivo con los valores de la serie} of the corresponding
 catalog. See \code{\link[=bde_catalog_load]{bde_catalog_load()}}.}
 
@@ -26,8 +26,8 @@ catalog. See \code{\link[=bde_catalog_load]{bde_catalog_load()}}.}
 \item{parse_numeric}{Logical. If \code{TRUE}, the columns are parsed to
 double (numeric) values. See \strong{Note}.}
 
-\item{cache_dir}{A path to a cache directory. The directory can also be set
-with options using \code{options(bde_cache_dir = "path/to/dir")}.}
+\item{cache_dir}{Path to a cache directory. The directory can also be set
+with \code{options(bde_cache_dir = "path/to/dir")}.}
 
 \item{update_cache}{Logical. If \code{TRUE}, the requested file is refreshed in
 \code{cache_dir}.}
@@ -38,13 +38,12 @@ with options using \code{options(bde_cache_dir = "path/to/dir")}.}
 requested series.}
 }
 \value{
-A \link[tibble:tbl_df]{tibble} with a \code{Date} field and the aliases of the
-series fields as described in the catalogs. See \code{\link[=bde_catalog_load]{bde_catalog_load()}}.
+A \link[tibble:tbl_df]{tibble} with a \code{Date} field and the aliases of
+the time series fields as described in the catalogs. See
+\code{\link[=bde_catalog_load]{bde_catalog_load()}}.
 }
 \description{
 Load a full BdE time series file.
-}
-\details{
 \subsection{About BdE file naming}{
 
 The series name is a positional code showing the location of the table. For
@@ -57,8 +56,8 @@ specific time series.
 }
 }
 \note{
-This function tries to coerce the columns to numbers. For some series, a
-warning may be displayed if the parser fails. You can override the default
+This function tries to coerce the columns to numbers. For some time series,
+a warning may be displayed if the parser fails. You can override the default
 behavior with \code{parse_numeric = FALSE}.
 }
 \examples{

--- a/man/bde_series_load.Rd
+++ b/man/bde_series_load.Rd
@@ -18,16 +18,15 @@ bde_series_load(
 )
 }
 \arguments{
-\item{series_code}{A numeric value, or one coercible with
-\code{\link[base:as.double]{base::as.double()}}, or a vector of time series codes, as defined in the
-field
-\verb{Número secuencial} of the corresponding series. See \code{\link[=bde_catalog_load]{bde_catalog_load()}}.}
+\item{series_code}{Numeric value, value coercible with \code{\link[base:as.double]{base::as.double()}},
+or vector of time series codes from the \verb{Número secuencial} field of the
+corresponding series. See \code{\link[=bde_catalog_load]{bde_catalog_load()}}.}
 
 \item{series_label}{Optional character string or vector of labels to assign
 to the extracted series.}
 
-\item{out_format}{The format to return, either \code{"wide"} or \code{"long"}.
-See \strong{Value} for details and the \strong{Examples} section.}
+\item{out_format}{The format to return, either \code{"wide"} or \code{"long"}. See
+\strong{Value} for details and the \strong{Examples} section.}
 
 \item{parse_dates}{Logical. If \code{TRUE}, date columns are parsed with
 \code{\link[=bde_parse_dates]{bde_parse_dates()}}.}
@@ -35,8 +34,8 @@ See \strong{Value} for details and the \strong{Examples} section.}
 \item{parse_numeric}{Logical. If \code{TRUE}, the columns are parsed to
 double (numeric) values. See \strong{Note}.}
 
-\item{cache_dir}{A path to a cache directory. The directory can also be set
-with options using \code{options(bde_cache_dir = "path/to/dir")}.}
+\item{cache_dir}{Path to a cache directory. The directory can also be set
+with \code{options(bde_cache_dir = "path/to/dir")}.}
 
 \item{update_cache}{Logical. If \code{TRUE}, the requested file is refreshed in
 \code{cache_dir}.}
@@ -62,23 +61,21 @@ corresponding value.
 \code{\link[tidyr:pivot_wider]{tidyr::pivot_wider()}}.
 }
 \description{
+Load a single BdE time series.
+
 The series alias is a positional code showing the location (column and/or
 row) of the series in the table. Although it is unique, it is not stable
-enough to use as the series ID because it may change when the series moves.
+enough to identify a time series because it may change when the series moves.
 
 To ensure series can still be identified after these changes, they are
 assigned a sequential number, referred to as \code{series_code} in this function.
 
-Note that a single series may appear in different tables, so it can have
-several aliases. If you need to search by alias, use
-\code{\link[=bde_series_full_load]{bde_series_full_load()}}.
-}
-\details{
-Load a single BdE time series.
+A single time series may appear in different tables, so it can have several
+aliases. If you need to search by alias, use \code{\link[=bde_series_full_load]{bde_series_full_load()}}.
 }
 \note{
-This function attempts to coerce the columns to numbers. For some series, a
-warning may be displayed if the parsing fails.
+This function attempts to coerce the columns to numbers. For some time
+series, a warning may be displayed if the parsing fails.
 }
 \examples{
 \dontshow{if (bde_check_access()) withAutoprint(\{ # examplesIf}

--- a/man/bde_tidy_palettes.Rd
+++ b/man/bde_tidy_palettes.Rd
@@ -17,10 +17,10 @@ bde_tidy_palettes(
 
 \item{palette}{A valid palette name.}
 
-\item{alpha}{An alpha transparency level in the range \verb{[0, 1]} (\code{0} means
-transparent and \code{1} means opaque). If missing (i.e., \code{alpha = NULL}), the
-function does not append opacity codes (\code{"FF"}) to the individual color
-hex codes. See \code{\link[ggplot2:alpha]{ggplot2::alpha()}}.}
+\item{alpha}{Alpha transparency level in the range \verb{[0, 1]}, where \code{0} is
+transparent and \code{1} is opaque. If \code{alpha = NULL}, the function does not
+append opacity codes (\code{"FF"}) to individual color hex codes. See
+\code{\link[ggplot2:alpha]{ggplot2::alpha()}}.}
 
 \item{rev}{Logical indicating whether to reverse the color order.}
 }
@@ -32,7 +32,6 @@ Manually defined palettes based on BdE publications. Each palette contains
 at most six colors.
 }
 \examples{
-
 # Show the BdE vivid palette.
 scales::show_col(bde_tidy_palettes(palette = "bde_vivid_pal"),
   labels = FALSE

--- a/man/scales_bde.Rd
+++ b/man/scales_bde.Rd
@@ -44,10 +44,10 @@ scale_fill_bde_c(
 \arguments{
 \item{palette}{BdE palette to apply. See \code{\link[=bde_tidy_palettes]{bde_tidy_palettes()}} for details.}
 
-\item{alpha}{An alpha transparency level in the range \verb{[0, 1]} (\code{0} means
-transparent and \code{1} means opaque). If missing (i.e., \code{alpha = NULL}), the
-function does not append opacity codes (\code{"FF"}) to the individual color
-hex codes. See \code{\link[ggplot2:alpha]{ggplot2::alpha()}}.}
+\item{alpha}{Alpha transparency level in the range \verb{[0, 1]}, where \code{0} is
+transparent and \code{1} is opaque. If \code{alpha = NULL}, the function does not
+append opacity codes (\code{"FF"}) to individual color hex codes. See
+\code{\link[ggplot2:alpha]{ggplot2::alpha()}}.}
 
 \item{rev}{Logical indicating whether to reverse the color order.}
 

--- a/man/tidyBdE-package.Rd
+++ b/man/tidyBdE-package.Rd
@@ -4,7 +4,7 @@
 \name{tidyBdE-package}
 \alias{tidyBdE}
 \alias{tidyBdE-package}
-\title{tidyBdE: Retrieve Data from 'Banco de España'}
+\title{tidyBdE: Retrieve Time Series Data from 'Banco de España'}
 \description{
 \if{html}{\figure{logo.png}{options: style='float: right' alt='logo' width='120'}}
 

--- a/pkgdown/_pkgdown.yml
+++ b/pkgdown/_pkgdown.yml
@@ -21,7 +21,7 @@ reference:
   - has_concept("catalog")
 
 - title: Series
-  desc: Load individual series and complete BdE time series files.
+  desc: Load individual time series and complete BdE time series files.
   contents:
   - has_concept("series")
 
@@ -31,7 +31,7 @@ reference:
   - has_concept("indicators")
 
 - title: Plot utilities
-  desc: BdE-inspired palettes, scales and themes for ggplot2 charts.
+  desc: BdE-inspired palettes, scales and themes for ggplot2 plots.
   contents:
   - has_concept("bde_plot")
 

--- a/tests/testthat/_snaps/bde_tidy_palettes.md
+++ b/tests/testthat/_snaps/bde_tidy_palettes.md
@@ -11,5 +11,5 @@
     Code
       nmore <- bde_tidy_palettes(n = 23)
     Message
-      tidyBdE> bde_vivid_pal contains 6 colors. You requested 23. Returning 6 colors.
+      ! Palette "bde_vivid_pal" contains 6 colors. You requested 23. Returning 6 colors.
 

--- a/tests/testthat/helper-local-data.R
+++ b/tests/testthat/helper-local-data.R
@@ -1,0 +1,64 @@
+write_bde_csv <- function(path, rows) {
+  dir.create(dirname(path), recursive = TRUE, showWarnings = FALSE)
+  write.table(
+    as.data.frame(rows, stringsAsFactors = FALSE),
+    path,
+    sep = ",",
+    quote = FALSE,
+    row.names = FALSE,
+    col.names = FALSE,
+    na = ""
+  )
+}
+
+write_test_catalog <- function(cache_dir, catalog = "TC") {
+  catalog_file <- file.path(
+    cache_dir,
+    paste0("catalogo_", tolower(catalog), ".csv")
+  )
+
+  header <- paste0("header", seq_len(17))
+  row <- c(
+    "Serie de prueba",
+    "12345",
+    "ALIAS1",
+    "TC_1_1.csv",
+    "Descripcion de prueba",
+    "Tipo",
+    "Unidad",
+    "0",
+    "2",
+    "Unidad y exponente",
+    "Mensual",
+    "ENE 2020",
+    "FEB 2020",
+    "2",
+    "Titulo de prueba",
+    "Fuente",
+    "Notas"
+  )
+
+  write_bde_csv(catalog_file, rbind(header, row))
+  catalog_file
+}
+
+write_test_series <- function(cache_dir, series_csv = "TC_1_1.csv") {
+  series_dir <- file.path(cache_dir, substr(series_csv, 1, 2))
+  series_file <- file.path(series_dir, tolower(series_csv))
+
+  rows <- rbind(
+    c("FREQ", "Monthly", "Monthly"),
+    c("UNIT", "Index", "Index"),
+    c("Fecha", "ALIAS1", "ALIAS2"),
+    c("Alias", "ALIAS1", "ALIAS2"),
+    c("Title", "First series", "Second series"),
+    c("Decimals", "2", "2"),
+    c("2020", "1.5", "2.5"),
+    c("ENE 2021", "_", "3.5"),
+    c("FUENTE", "BdE", "BdE"),
+    c("NOTAS", "Test note", "Test note")
+  )
+
+  write_bde_csv(series_file, rows)
+  series_file
+}

--- a/tests/testthat/test-catalogs.R
+++ b/tests/testthat/test-catalogs.R
@@ -10,7 +10,7 @@ test_that("Catalogs offline", {
 
   expect_message(
     bde_catalog_update("TC", cache_dir = dir),
-    "Testing offline\\."
+    "Testing offline mode\\."
   )
 
   table1 <- bde_catalog_load("TI", cache_dir = dir)
@@ -48,11 +48,11 @@ test_that("Messages", {
   options(bde_test_offline = FALSE)
   expect_message(
     bde_catalog_load("TC", verbose = TRUE, cache_dir = dir),
-    "Need to download catalog TC\\.|Cached version of TC detected\\."
+    "Downloading catalog|Using cached catalog"
   )
   expect_message(
     bde_catalog_load("TC", verbose = TRUE, cache_dir = dir),
-    "Cached version of TC detected\\."
+    "Using cached catalog"
   )
 })
 
@@ -66,11 +66,11 @@ test_that("Old tests: Catalogs", {
 
   expect_message(
     bde_catalog_load("TC", cache_dir = tempdir(), verbose = TRUE),
-    "Cached version of TC detected\\.|Need to download catalog TC\\."
+    "Using cached catalog|Downloading catalog"
   )
   expect_message(
     bde_catalog_load("TC", cache_dir = NULL, verbose = TRUE),
-    "Cached version of TC detected\\.|Need to download catalog TC\\."
+    "Using cached catalog|Downloading catalog"
   )
   expect_message(
     bde_catalog_load(
@@ -78,7 +78,7 @@ test_that("Old tests: Catalogs", {
       cache_dir = file.path(tempdir(), "aa"),
       verbose = TRUE
     ),
-    "Cache directory created at|Need to download catalog TC\\."
+    "Created cache directory|Downloading catalog"
   )
 
   expect_silent(bde_catalog_load("ALL"))
@@ -93,7 +93,7 @@ test_that("Old tests: Catalogs", {
       cache_dir = tempdir(),
       verbose = TRUE
     ),
-    "Updating catalogs: TC"
+    "Updating catalogs: TC\\."
   )
   expect_silent(bde_catalog_update("ALL", cache_dir = tempdir()))
   expect_silent(bde_catalog_update("TC", cache_dir = tempdir()))
@@ -103,7 +103,7 @@ test_that("Old tests: Catalogs", {
   options(bde_cache_dir = file.path(tempdir(), "test"))
   expect_message(
     bde_catalog_update("TC", verbose = TRUE),
-    "Cache directory detected in options:"
+    "Using cache directory from options:"
   )
   # Reset
   options(bde_cache_dir = init_cache_dir)

--- a/tests/testthat/test-local-coverage.R
+++ b/tests/testthat/test-local-coverage.R
@@ -1,0 +1,278 @@
+test_that("catalog helpers work with local CSV files", {
+  dir <- file.path(tempdir(), "tidybde-local-catalogs")
+  unlink(dir, recursive = TRUE, force = TRUE)
+  write_test_catalog(dir, "TC")
+
+  expect_message(
+    catalog <- bde_catalog_load("TC", cache_dir = dir, verbose = TRUE),
+    "Using cached catalog"
+  )
+
+  expect_s3_class(catalog, "tbl_df")
+  expect_equal(nrow(catalog), 1)
+  expect_equal(catalog$Numero_secuencial, 12345)
+  expect_s3_class(catalog$Fecha_de_la_primera_observacion, "Date")
+
+  raw_catalog <- bde_catalog_load("TC", cache_dir = dir, parse_dates = FALSE)
+  expect_type(raw_catalog$Fecha_de_la_primera_observacion, "character")
+
+  found <- bde_catalog_search("Titulo", catalog = "TC", cache_dir = dir)
+  expect_equal(found$Alias_de_la_serie, "ALIAS1")
+
+  expect_error(
+    bde_catalog_search("No existe", catalog = "TC", cache_dir = dir),
+    "No matches found"
+  )
+})
+
+test_that("catalog updates can be tested without network access", {
+  dir <- file.path(tempdir(), "tidybde-local-update")
+  unlink(dir, recursive = TRUE, force = TRUE)
+
+  testthat::local_mocked_bindings(
+    bde_check_access = function() TRUE,
+    bde_hlp_download = function(url, local_file, verbose) {
+      catalog <- sub("catalogo_([a-z]+)[.]csv$", "\\1", basename(local_file))
+      write_test_catalog(dirname(local_file), toupper(catalog))
+      TRUE
+    }
+  )
+
+  expect_message(
+    bde_catalog_update("TC", cache_dir = dir, verbose = TRUE),
+    "Updating catalogs: TC\\."
+  )
+  expect_true(file.exists(file.path(dir, "catalogo_tc.csv")))
+
+  expect_message(
+    bde_catalog_update("ALL", cache_dir = dir, verbose = TRUE),
+    "Updating catalogs: BE, SI, TC, TI, PB\\."
+  )
+})
+
+test_that("cache helper covers option, suffix and creation paths", {
+  dir <- file.path(tempdir(), "tidybde-cache-helper")
+  unlink(dir, recursive = TRUE, force = TRUE)
+
+  expect_message(
+    created <- bde_hlp_cachedir(dir, verbose = TRUE),
+    "Created cache directory"
+  )
+  expect_equal(created, dir)
+
+  options(bde_cache_dir = dir)
+  on.exit(options(bde_cache_dir = NULL))
+
+  expect_message(
+    from_option <- bde_hlp_cachedir(verbose = TRUE, suffix = "TC"),
+    "Using cache directory from options"
+  )
+  expect_equal(basename(from_option), "TC")
+
+  options(bde_cache_dir = NULL)
+  expect_message(
+    temp_cache <- bde_hlp_cachedir(verbose = TRUE, suffix = "SI"),
+    "Using temporary cache directory"
+  )
+  expect_equal(basename(temp_cache), "SI")
+})
+
+test_that("series loaders work with local CSV files", {
+  dir <- file.path(tempdir(), "tidybde-local-series")
+  unlink(dir, recursive = TRUE, force = TRUE)
+  write_test_catalog(dir, "TC")
+  write_test_series(dir, "TC_1_1.csv")
+
+  expect_message(
+    full <- bde_series_full_load("TC_1_1.csv", cache_dir = dir, verbose = TRUE),
+    "Reading file"
+  )
+  expect_s3_class(full, "tbl_df")
+  expect_equal(names(full), c("Date", "ALIAS1", "ALIAS2"))
+  expect_s3_class(full$Date, "Date")
+  expect_equal(full$ALIAS1[1], 1.5)
+  expect_true(is.na(full$ALIAS1[2]))
+
+  raw <- bde_series_full_load(
+    "TC_1_1",
+    cache_dir = dir,
+    parse_dates = FALSE,
+    parse_numeric = FALSE
+  )
+  expect_type(raw$Date, "character")
+  expect_type(raw$ALIAS1, "character")
+
+  meta <- bde_series_full_load(
+    "TC_1_1.csv",
+    cache_dir = dir,
+    extract_metadata = TRUE
+  )
+  expect_equal(nrow(meta), 6)
+
+  wide <- bde_series_load(
+    12345,
+    series_label = "Test series",
+    cache_dir = dir
+  )
+  expect_equal(names(wide), c("Date", "Test series"))
+
+  long <- bde_series_load(
+    12345,
+    series_label = "Test series",
+    cache_dir = dir,
+    out_format = "long"
+  )
+  expect_equal(names(long), c("Date", "serie_name", "serie_value"))
+  expect_s3_class(long$serie_name, "factor")
+})
+
+test_that("series loader reports unavailable aliases", {
+  dir <- file.path(tempdir(), "tidybde-local-missing-alias")
+  unlink(dir, recursive = TRUE, force = TRUE)
+  catalog_file <- write_test_catalog(dir, "TC")
+  catalog <- readLines(catalog_file)
+  catalog <- sub("ALIAS1", "MISSING_ALIAS", catalog, fixed = TRUE)
+  writeLines(catalog, catalog_file)
+  write_test_series(dir, "TC_1_1.csv")
+
+  expect_message(
+    out <- bde_series_load(12345, cache_dir = dir, verbose = TRUE),
+    "not available"
+  )
+  expect_equal(nrow(out), 0)
+})
+
+test_that("series loader validates labels before loading catalogs", {
+  expect_error(
+    bde_series_load(c(1, 2), series_label = c("a", NA)),
+    "must not contain missing values"
+  )
+  expect_error(
+    bde_series_load(c(1, 2), series_label = "a"),
+    "must have the same length"
+  )
+})
+
+test_that("series loader reports missing catalog matches", {
+  dir <- file.path(tempdir(), "tidybde-local-missing-code")
+  unlink(dir, recursive = TRUE, force = TRUE)
+  write_test_catalog(dir, "TC")
+
+  expect_message(
+    out <- bde_series_load(99999, cache_dir = dir, verbose = TRUE),
+    "was not found in catalogs"
+  )
+  expect_equal(nrow(out), 0)
+})
+
+test_that("full series loader covers download branches", {
+  dir <- file.path(tempdir(), "tidybde-local-download")
+  unlink(dir, recursive = TRUE, force = TRUE)
+
+  options(bde_test_offline = TRUE)
+  on.exit(options(bde_test_offline = FALSE))
+
+  expect_message(
+    offline <- bde_series_full_load("TC_1_2.csv", cache_dir = dir),
+    "Testing offline mode"
+  )
+  expect_equal(nrow(offline), 0)
+
+  options(bde_test_offline = FALSE)
+  testthat::local_mocked_bindings(
+    bde_check_access = function() TRUE,
+    bde_hlp_download = function(url, local_file, verbose) {
+      writeLines(character(), local_file)
+      FALSE
+    }
+  )
+
+  expect_null(bde_series_full_load("TC_1_3.csv", cache_dir = dir))
+  expect_false(file.exists(file.path(dir, "TC", "tc_1_3.csv")))
+})
+
+test_that("full series loader creates default cache subdirectories", {
+  unlink(file.path(tempdir(), "ZZ"), recursive = TRUE, force = TRUE)
+  options(bde_test_offline = TRUE)
+  on.exit(options(bde_test_offline = FALSE))
+
+  expect_message(
+    out <- bde_series_full_load("ZZ_1_1.csv", cache_dir = NULL),
+    "Testing offline mode"
+  )
+  expect_equal(nrow(out), 0)
+  expect_true(dir.exists(file.path(tempdir(), "ZZ")))
+})
+
+test_that("download helper handles mocked warnings", {
+  local_file <- tempfile()
+  testthat::local_mocked_bindings(
+    download.file = function(...) {
+      warning("offline")
+    }
+  )
+
+  expect_message(
+    ok <- bde_hlp_download("https://example.com/file.csv", local_file, TRUE),
+    "Trying again|not reachable"
+  )
+  expect_false(ok)
+})
+
+test_that("download helper reports successful downloads", {
+  local_file <- tempfile()
+  testthat::local_mocked_bindings(
+    download.file = function(url, destfile, ...) {
+      writeLines("ok", destfile)
+      0
+    }
+  )
+
+  expect_message(
+    ok <- bde_hlp_download("https://example.com/file.csv", local_file, TRUE),
+    "Downloading file"
+  )
+  expect_true(ok)
+  expect_true(file.exists(local_file))
+})
+
+test_that("type conversion helpers convert non-preserved columns", {
+  tbl <- tibble::tibble(
+    keep = 1,
+    convert = 2,
+    text = "3"
+  )
+
+  as_char <- bde_hlp_tochar(tbl, preserve = "keep")
+  expect_type(as_char$keep, "double")
+  expect_type(as_char$convert, "character")
+
+  as_double <- bde_hlp_todouble(as_char, preserve = "convert")
+  expect_type(as_double$text, "double")
+  expect_type(as_double$convert, "character")
+})
+
+test_that("indicator wrappers delegate to the shared loader", {
+  testthat::local_mocked_bindings(
+    bde_series_load = function(series_code, series_label, ...) {
+      tibble::tibble(
+        Date = as.Date(c("2020-01-01", "2020-01-02")),
+        value = c(NA, 1)
+      )
+    }
+  )
+
+  indicators <- list(
+    bde_ind_gdp_var(),
+    bde_ind_unemployment_rate(),
+    bde_ind_euribor_12m_monthly(),
+    bde_ind_euribor_12m_daily(),
+    bde_ind_cpi_var(),
+    bde_ind_ibex_monthly(),
+    bde_ind_ibex_daily(),
+    bde_ind_gdp_quarterly(),
+    bde_ind_population()
+  )
+
+  expect_true(all(vapply(indicators, nrow, integer(1)) == 1))
+})

--- a/tests/testthat/test-series.R
+++ b/tests/testthat/test-series.R
@@ -13,7 +13,7 @@ test_that("Indicators", {
       cache_dir = tempdir(),
       verbose = TRUE
     ),
-    "Reading file ti_1_1.csv from cache\\.|Downloading file from"
+    "Reading file .*ti_1_1.csv.* from cache\\.|Downloading file from"
   )
   expect_message(
     bde_series_full_load(
@@ -21,7 +21,7 @@ test_that("Indicators", {
       cache_dir = NULL,
       verbose = TRUE
     ),
-    "Reading file ti_1_1.csv from cache\\.|Downloading file from"
+    "Reading file .*ti_1_1.csv.* from cache\\.|Downloading file from"
   )
   expect_message(
     bde_series_full_load(
@@ -29,7 +29,7 @@ test_that("Indicators", {
       cache_dir = NULL,
       verbose = TRUE
     ),
-    "Reading file cf0101.csv from cache\\.|Downloading file from"
+    "Reading file .*cf0101.csv.* from cache\\.|Downloading file from"
   )
   expect_silent(bde_series_full_load("CF0101"))
 
@@ -43,7 +43,7 @@ test_that("Indicators", {
   expect_identical(bde_series_load(12345678910), bde_hlp_return_null())
   expect_error(
     bde_series_load(c(573234, 573214), series_label = c(1, NA)),
-    "`series_label` must not contain NA values\\."
+    "`series_label` must not contain missing values\\."
   )
   expect_error(
     bde_series_load(c(573234, 573214), series_label = c("1", "1")),
@@ -63,7 +63,7 @@ test_that("Indicators", {
   expect_silent(bde_series_load(573234, extract_metadata = TRUE))
   expect_message(
     bde_series_load(573234, verbose = TRUE),
-    "Extracting series 573234\\."
+    "Extracting series"
   )
 
   meta <- bde_series_load(573234, extract_metadata = TRUE)
@@ -120,7 +120,7 @@ test_that("Series full", {
   # Can't download series
   expect_message(
     bde_series_full_load(all_names[2], cache_dir = dir),
-    "Testing offline\\."
+    "Testing offline mode\\."
   )
 
   fail <- bde_series_full_load(all_names[2], cache_dir = dir)

--- a/vignettes/articles/mainseries.qmd
+++ b/vignettes/articles/mainseries.qmd
@@ -1,5 +1,5 @@
 ---
-title: "Main macroeconomic series"
+title: "Main macroeconomic indicators"
 description: Evolution of selected Spanish economic indicators.
 date: "`r Sys.Date()`"
 knitr:
@@ -14,8 +14,8 @@ knitr:
     out.width: "100%"
 ---
 
-This article shows selected Spanish economic indicators using Banco de España
-data.
+This article shows selected Spanish macroeconomic indicators using Banco de
+España data.
 
 Last updated: **`r format(Sys.Date(), "%d-%B-%Y")`**.
 
@@ -25,7 +25,7 @@ library(ggplot2)
 library(dplyr)
 library(tidyr)
 
-# Set plot parameters and date range.
+# Set plot parameters and the date range.
 col <- bde_tidy_palettes(1, "bde_rose_pal")
 date <- Sys.Date()
 ny <- as.numeric(format(date, format = "%Y")) - 6
@@ -51,7 +51,7 @@ dataset$LastY <- dataset$data +
   lag(dataset$data, 2) +
   lag(dataset$data, 3)
 
-# Filter observations.
+# Keep observations in the selected date range.
 dataset <- dataset |>
   filter(Date >= nd) |>
   mutate(data = LastY) |>

--- a/vignettes/articles/seriesindex.qmd
+++ b/vignettes/articles/seriesindex.qmd
@@ -1,7 +1,7 @@
 ---
 title: "Series index"
 date: "`r Sys.Date()`"
-description: Summary of information available through tidyBdE.
+description: Summary of time series available through tidyBdE.
 toc: true
 tbl-cap-location: bottom
 knitr:
@@ -16,10 +16,10 @@ knitr:
     out.width: "100%"
 ---
 
-This table lists the series available in the catalog. Last updated:
+This table lists time series available in the catalog. Last updated:
 **`r format(Sys.Date(), "%d-%B-%Y")`**.
 
-Use the sequential number to load a series, as shown in the example.
+Use the sequential number to load a time series, as shown in the example.
 
 ## Summary
 
@@ -72,7 +72,7 @@ reactable(
 
 ## Example {#example}
 
-Workflow for searching and extracting a specific series:
+Workflow for searching and extracting a specific time series:
 
 ```{r}
 #| label: tbl-example
@@ -92,26 +92,26 @@ fr |>
 ```{r}
 #| label: tbl-meta
 #| tbl-cap: Metadata of the indicator
-# Extract the first series using tidyverse style.
+# Extract the first matching time series.
 fr |>
-  # Select the series ID.
+  # Select the series code.
   select(Numero_secuencial) |>
   # Select the first record.
   slice(1) |>
   # Convert to numeric.
   as.double() |>
-  # Load the series.
+  # Load the time series.
   bde_series_load()
 
-# Show the metadata.
+# Show the series metadata.
 fr |>
-  # Select the series ID.
+  # Select the series code.
   select(Numero_secuencial) |>
   # Select the first record.
   slice(1) |>
   # Convert to numeric.
   as.double() |>
-  # Load its metadata.
+  # Load the series metadata.
   bde_series_load(extract_metadata = TRUE) |>
   # Display the table in the vignette.
   knitr::kable()

--- a/vignettes/tidyBdE.qmd
+++ b/vignettes/tidyBdE.qmd
@@ -57,11 +57,11 @@ Search results
 :::
 
 **Note:** BdE metadata is currently available in Spanish only, so search terms
-must be in Spanish to retrieve results. The institution is working on an
-English version.
+must be in Spanish to retrieve results. The institution is working on an English
+version.
 
-After finding a time series, load the GBP/EUR exchange rate using the
-sequential number reference (`Numero_secuencial`):
+After finding a time series, load the GBP/EUR exchange rate using the sequential
+number reference (`Numero_secuencial`):
 
 
 ``` r
@@ -99,8 +99,7 @@ time_series
 
 ## Plot time series
 
-The package also provides a custom **ggplot2** theme based on BdE
-publications:
+The package also provides a custom **ggplot2** theme based on BdE publications:
 
 
 ``` r

--- a/vignettes/tidyBdE.qmd
+++ b/vignettes/tidyBdE.qmd
@@ -14,18 +14,18 @@ vignette: >
 
 **tidyBdE** is an **R** package that retrieves data from [Banco de
 España](https://www.bde.es/webbe/en/estadisticas/recursos/descargas-completas.html).
-Data are returned as a [tibble](https://tibble.tidyverse.org/), and the
-package automatically detects the format of each time series (dates, characters
-and numbers).
+Data are returned as [**tibble**](https://tibble.tidyverse.org/) objects. The
+package automatically detects the format of each time series field, including
+dates, character fields and numeric fields.
 
-## Search series
+## Search time series
 
 Banco de España (**BdE**) provides several time series, either produced by the
-institution itself or compiled from other sources, such as
+institution or compiled from other sources, such as
 [Eurostat](https://ec.europa.eu/eurostat) or [INE](https://www.ine.es/).
 
 The basic entry point for searching time series is the catalog. You can search
-for series by name:
+for time series by name:
 
 
 ``` r
@@ -56,19 +56,19 @@ xr_gbp |>
 Search results
 :::
 
-**Note:** BdE metadata is currently provided in Spanish only, so search terms
-must be provided in Spanish to retrieve results. The institution is working on
-an English version.
+**Note:** BdE metadata is currently available in Spanish only, so search terms
+must be in Spanish to retrieve results. The institution is working on an
+English version.
 
-After finding a series, load the GBP/EUR exchange rate using the sequential
-number reference (`Numero_secuencial`):
+After finding a time series, load the GBP/EUR exchange rate using the
+sequential number reference (`Numero_secuencial`):
 
 
 ``` r
 seq_number <- xr_gbp |>
   # Select the first record.
   slice(1) |>
-  # Get the series ID.
+  # Get the series code.
   pull(Numero_secuencial) |>
   # Convert to numeric.
   as.double()
@@ -97,7 +97,7 @@ time_series
 #> # ℹ 2,806 more rows
 ```
 
-## Plot series
+## Plot time series
 
 The package also provides a custom **ggplot2** theme based on BdE
 publications:
@@ -130,8 +130,8 @@ ggplot(time_series, aes(x = Date, y = EUR_GBP_XR)) +
 <p class="caption">Figure 1: EUR/GBP Exchange Rate (2010-2020)</p>
 </div>
 
-The package also provides convenience functions for selected macroeconomic
-series, so you do not need to search manually:
+The package also provides convenience functions for selected Spanish
+macroeconomic indicators, so you do not need to search manually:
 
 
 ``` r
@@ -162,8 +162,7 @@ ggplot(plotseries, aes(x = Date, y = serie_value)) +
 
 ## A note on caching
 
-You can use **tidyBdE** to create a local cache by setting the following
-option:
+Create a local cache by setting the following option:
 
 
 ``` r
@@ -171,9 +170,9 @@ options(bde_cache_dir = "./path/to/location")
 ```
 
 When this option is set, **tidyBdE** looks for cached files in the
-`bde_cache_dir` directory and loads them, speeding up data retrieval.
+`bde_cache_dir` directory and loads them to speed up data retrieval.
 
-You can update the data after monthly or quarterly releases with the following
+Update cached data after monthly or quarterly releases with the following
 commands:
 
 

--- a/vignettes/tidyBdE.qmd.orig
+++ b/vignettes/tidyBdE.qmd.orig
@@ -73,11 +73,11 @@ Search results
 :::
 
 **Note:** BdE metadata is currently available in Spanish only, so search terms
-must be in Spanish to retrieve results. The institution is working on an
-English version.
+must be in Spanish to retrieve results. The institution is working on an English
+version.
 
-After finding a time series, load the GBP/EUR exchange rate using the
-sequential number reference (`Numero_secuencial`):
+After finding a time series, load the GBP/EUR exchange rate using the sequential
+number reference (`Numero_secuencial`):
 
 ```{r}
 #| label: find
@@ -100,8 +100,7 @@ time_series
 
 ## Plot time series
 
-The package also provides a custom **ggplot2** theme based on BdE
-publications:
+The package also provides a custom **ggplot2** theme based on BdE publications:
 
 ```{r}
 #| label: chart

--- a/vignettes/tidyBdE.qmd.orig
+++ b/vignettes/tidyBdE.qmd.orig
@@ -29,18 +29,18 @@ library(tidyBdE)
 
 **tidyBdE** is an **R** package that retrieves data from [Banco de
 España](https://www.bde.es/webbe/en/estadisticas/recursos/descargas-completas.html).
-Data are returned as a [tibble](https://tibble.tidyverse.org/), and the
-package automatically detects the format of each time series (dates, characters
-and numbers).
+Data are returned as [**tibble**](https://tibble.tidyverse.org/) objects. The
+package automatically detects the format of each time series field, including
+dates, character fields and numeric fields.
 
-## Search series
+## Search time series
 
 Banco de España (**BdE**) provides several time series, either produced by the
-institution itself or compiled from other sources, such as
+institution or compiled from other sources, such as
 [Eurostat](https://ec.europa.eu/eurostat) or [INE](https://www.ine.es/).
 
 The basic entry point for searching time series is the catalog. You can search
-for series by name:
+for time series by name:
 
 ```{r}
 #| label: search
@@ -72,19 +72,19 @@ xr_gbp |>
 Search results
 :::
 
-**Note:** BdE metadata is currently provided in Spanish only, so search terms
-must be provided in Spanish to retrieve results. The institution is working on
-an English version.
+**Note:** BdE metadata is currently available in Spanish only, so search terms
+must be in Spanish to retrieve results. The institution is working on an
+English version.
 
-After finding a series, load the GBP/EUR exchange rate using the sequential
-number reference (`Numero_secuencial`):
+After finding a time series, load the GBP/EUR exchange rate using the
+sequential number reference (`Numero_secuencial`):
 
 ```{r}
 #| label: find
 seq_number <- xr_gbp |>
   # Select the first record.
   slice(1) |>
-  # Get the series ID.
+  # Get the series code.
   pull(Numero_secuencial) |>
   # Convert to numeric.
   as.double()
@@ -98,7 +98,7 @@ time_series <- bde_series_load(seq_number, series_label = "EUR_GBP_XR") |>
 time_series
 ```
 
-## Plot series
+## Plot time series
 
 The package also provides a custom **ggplot2** theme based on BdE
 publications:
@@ -129,8 +129,8 @@ ggplot(time_series, aes(x = Date, y = EUR_GBP_XR)) +
   theme_tidybde()
 ```
 
-The package also provides convenience functions for selected macroeconomic
-series, so you do not need to search manually:
+The package also provides convenience functions for selected Spanish
+macroeconomic indicators, so you do not need to search manually:
 
 ```{r}
 #| label: macroseries
@@ -159,8 +159,7 @@ ggplot(plotseries, aes(x = Date, y = serie_value)) +
 
 ## A note on caching
 
-You can use **tidyBdE** to create a local cache by setting the following
-option:
+Create a local cache by setting the following option:
 
 ```{r}
 #| eval: false
@@ -168,9 +167,9 @@ options(bde_cache_dir = "./path/to/location")
 ```
 
 When this option is set, **tidyBdE** looks for cached files in the
-`bde_cache_dir` directory and loads them, speeding up data retrieval.
+`bde_cache_dir` directory and loads them to speed up data retrieval.
 
-You can update the data after monthly or quarterly releases with the following
+Update cached data after monthly or quarterly releases with the following
 commands:
 
 ```{r}


### PR DESCRIPTION
- Internal code was refactored with AI assistance to reduce duplication in indicator wrappers and **ggplot2** scale helpers.
- Messages and package errors now use **cli**, with AI-assisted wording updates and without the former `tidyBdE>` prefix.
- Roxygen2 documentation was reviewed with AI assistance and tag order was made consistent across source files.
- Tests were refactored and expanded with local fixtures, mocks and snapshot updates, reaching 100% line coverage in `devtools:::test_coverage()`.
